### PR TITLE
F #-: Adds cloud provider and CAPONE docs

### DIFF
--- a/content/integrations/automation_tools/kubernetes_cloud_provider.md
+++ b/content/integrations/automation_tools/kubernetes_cloud_provider.md
@@ -1,0 +1,17 @@
+---
+title: "Kubernetes Cloud Provider"
+date: "2025-05-19"
+description:
+categories:
+pageintoc: "269"
+tags:
+weight: "3"
+---
+
+<a id="k8s-cloud-provider"></a>
+
+<!--# Kubernetes Cloud Provider -->
+
+The [Kubernetes cloud-provider interface](https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cloud-provider) allows Kubernetes to interact with the underlying cloud infrastructure through the cluster-provider controller. This allows Kubernetes to manage cloud resources like nodes, load-balancers, etc.
+
+OpenNebula offers its own Kubernetes cloud-provider implementation for providing nodes and load-balancers to Kubernetes clusters. More information on the [OpenNebula Cloud-provider documentation](https://github.com/OpenNebula/cloud-provider-opennebula/wiki).

--- a/content/integrations/automation_tools/kubernetes_cluster_api.md
+++ b/content/integrations/automation_tools/kubernetes_cluster_api.md
@@ -3,7 +3,7 @@ title: "Kubernetes Cluster API Integration"
 date: "2025-02-17"
 description:
 categories:
-pageintoc: "266"
+pageintoc: "268"
 tags:
 weight: "3"
 ---
@@ -12,4 +12,6 @@ weight: "3"
 
 <!--# Kubernetes Cluster API -->
 
-TBC.
+Kubernetes provides the Cluster API, a set of declarative APIs and tooling for simplifying and automating the provisioning, upgrade, delete and operation of multiple Kubernetes clusters in a declarative and extensible way, like if they were workloads of a management Kubernetes Cluster.
+
+OpenNebula provides its own implementation of the Cluster API (CAPONE) to easily provision and operate Kubernetes clusters. It interacts with OpenNebula for provision dedicated VMs (through the [OpenNebula Cloud Provider](./kubernetes_cloud_provider.md)) and build the Kubernetes workload cluster, including the control plane nodes. More information on the [OpenNebula Cluster Api Provider wiki](https://github.com/OpenNebula/cluster-api-provider-opennebula/wiki).


### PR DESCRIPTION
- Adds quick intro and references for Cloud Provider wiki documentation.
- Adds quick intro and references for CAPONE wiki documentation.
- Fixes repeated TOC index for CAPONE docs.