### PR TITLE
B #-: Move fs_lvm's BRIDGE_LIST from SYS to IMG ds

### DIFF
--- a/content/product/cluster_configuration/storage_system/lvm_drivers.md
+++ b/content/product/cluster_configuration/storage_system/lvm_drivers.md
@@ -47,13 +47,12 @@ Once the Host and Front-end storage is set up, the OpenNebula configuration comp
 
 To create a new SAN/LVM System Datastore, you need to set the following (template) parameters:
 
-| Attribute     | Description                                                                                                                                    |
-|---------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| `NAME`        | Name of Datastore                                                                                                                              |
-| `TM_MAD`      | `fs_lvm_ssh`                                                                                                                                   |
-| `TYPE`        | `SYSTEM_DS`                                                                                                                                    |
-| `BRIDGE_LIST` | List of Hosts with access to the LV to perform<br/>driver operations.<br/>**NOT** needed if the Front-end is configured to<br/>access the LVs. |
-| `DISK_TYPE`   | `BLOCK` (used for volatile disks)                                                                                                              |
+| Attribute     | Description                       |
+|---------------|-----------------------------------|
+| `NAME`        | Name of Datastore                 |
+| `TYPE`        | `SYSTEM_DS`                       |
+| `TM_MAD`      | `fs_lvm_ssh`                      |
+| `DISK_TYPE`   | `BLOCK` (used for volatile disks) |
 
 For example:
 
@@ -62,7 +61,6 @@ For example:
 NAME   = lvm_system
 TM_MAD = fs_lvm_ssh
 TYPE   = SYSTEM_DS
-BRIDGE_LIST = "node1.kvm.lvm node2.kvm.lvm"
 DISK_TYPE = BLOCK
 
 > onedatastore create ds.conf
@@ -92,6 +90,7 @@ DS_MAD = fs
 TM_MAD = fs_lvm_ssh
 DISK_TYPE = "BLOCK"
 TYPE = IMAGE_DS
+BRIDGE_LIST = "node1.kvm.lvm node2.kvm.lvm"
 SAFE_DIRS="/var/tmp /tmp"
 
 > onedatastore create ds.conf

--- a/content/software/release_information/release_notes_70/compatibility.md
+++ b/content/software/release_information/release_notes_70/compatibility.md
@@ -102,6 +102,10 @@ Note: Caching support is not yet included in this release but is in an advanced 
 
 <a id="compatibility-guide-labels"></a>
 
+## SAN driver BRIDGE_LIST location change
+
+To make its behaviour consistent with other drivers, [LVM/SAN](/product/cluster_configuration/storage_system/lvm_drivers/) drivers now define the `BRIDGE_LIST` attribute in the IMAGE datastore, instead of in the SYSTEM one.
+
 ## Labels on Sunstone
 
 Starting from version 7.0, the labels system in Sunstone has been revamped, moving away from the old global/system-wide approach towards a more user/group-specific structure. 


### PR DESCRIPTION
Document changes from https://github.com/OpenNebula/one-ee/pull/3657/commits/7f813d5c286fbdbe1395e4584114c47795cc2805: LVM drivers look for the BRIDGE_LIST attribute in the IMAGE datastore instead of in the SYSTEM one.