### PR TITLE
Bump Restic version in platform notes

### DIFF
--- a/content/software/release_information/release_notes_70/platform_notes.md
+++ b/content/software/release_information/release_notes_70/platform_notes.md
@@ -88,7 +88,7 @@ More information: [one-apps wiki](https://github.com/OpenNebula/one-apps/wiki)
 | Component                     | Version   | More information                                                                                                                    |
 |-------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
 | Prometheus monitoring toolkit | 2.53.1    | [Monitoring and Alerting Installation]({{% relref "../../../product/cloud_system_administration/prometheus/install.md#monitor-alert-installation" %}}) |
-| Restic backup backend         | 0.16.5    | [Backup Datastore: Restic]({{% relref "../../../product/cluster_configuration/backup_system/restic.md#vm-backups-restic" %}})                                        |
+| Restic backup backend         | 0.17.3    | [Backup Datastore: Restic]({{% relref "../../../product/cluster_configuration/backup_system/restic.md#vm-backups-restic" %}})                                        |
 | Veeam                         | 12.3.1    | [Veeam Backup (EE)]({{% relref "../../../integrations/backup_extensions/veeam.md" %}}) |
 
 ### Sunstone


### PR DESCRIPTION
From release checklist (+ after https://github.com/OpenNebula/one-ee/pull/3697).