### PR TITLE
M #-: Remove rubygems from platform notes

### DIFF
--- a/content/software/release_information/release_notes_70/platform_notes.md
+++ b/content/software/release_information/release_notes_70/platform_notes.md
@@ -28,7 +28,6 @@ This is the list of the individual platform components that have been through th
 | Debian                   | 11, 12                                     | [Front-End Installation]({{% relref "front_end_installation" %}}).<br/>Not certified to manage VMware infrastructures |
 | MariaDB or MySQL         | Version included in the Linux distribution | [MySQL Setup]({{% relref "../../../software/installation_process/manual_installation/database#mysql" %}})                                                                  |
 | SQLite                   | Version included in the Linux distribution | Default DB, no configuration needed                                                                                                                                                         |
-| Ruby Gems                | Versions installed by opennebula-rubygems  | Detailed information in `/usr/share/one/Gemfile`                                                                                                                                            |
 
 {{< alert title="Note" color="success" >}}
 Support for nodes’ operating system ensures that the latest two LTS releases feature certified packages.{{< /alert >}}


### PR DESCRIPTION
#### Description

* Ruby gems no longer needs to be listed under frontend components as Ruby Sunstone has been removed from 7.0