### PR TITLE
M #-: Place version var in main docs page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -9,7 +9,7 @@ no_list: true
 breadcrumb_disable: true
 ---
 
-# Welcome to OpenNebula 7.0
+# Welcome to OpenNebula {{< version >}}
 
 <p></p>
 


### PR DESCRIPTION
Replace version number with `{{< version >}}` on the h1 header of the main docs page.

Tested locally.

This would go to branches one-7.0 and master.