### PR TITLE
M #-: Change button color

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -30,6 +30,13 @@
   } 
 }
 
+// Button color for copying code on highlighted code blocks
+.td-content {
+  button.td-click-to-copy {
+    color: #cecece !important;
+  }
+}
+
 .td-card-group.card-group {
   @extend .td-max-width-on-larger-screens;
 }


### PR DESCRIPTION
Change color of the button to copy contents of highlighted code blocks, since it's not visible in Light Mode.

This would be for branches one-7.0 and master