### PR TITLE
M #-: Change 'one_version' in sample conf files to {{< version >}} variable

### DIFF
--- a/content/software/installation_process/automatic_installation_with_onedeploy/one_deploy_overview.md
+++ b/content/software/installation_process/automatic_installation_with_onedeploy/one_deploy_overview.md
@@ -32,12 +32,11 @@ The basic procedure is as follows:
 
 Ansible is an agentless platform and uses SSH as the default transport for deployment. The control node must be able to communicate with the managed nodes via SSH.
 
-<!-- ![image](/images/one_deploy_basic_arch.png&width=1612&height=718) -->
-
-{{< image path=/images/one_deploy_basic_arch.png width=720 height=446 >}}
+{{< image path=/images/one_deploy_basic_arch.png width=1080 height=669 >}}
 
 <!-- ![image](/images/one_deploy_basic_arch.png)
 <br/> -->
+<p></p>
 
 It is worth noting that you can use the control node itself as a managed node. In the tutorials included in this documentation, the OpenNebula Front-end is installed on the Ansible control node and the Hypervisors on the managed nodes.
 

--- a/content/software/installation_process/automatic_installation_with_onedeploy/one_deploy_tutorial_local_ds.md
+++ b/content/software/installation_process/automatic_installation_with_onedeploy/one_deploy_tutorial_local_ds.md
@@ -20,7 +20,7 @@ In this tutorial, we’ll use [OneDeploy](https://github.com/OpenNebula/one-depl
 
 This sample architecture uses a basic network configuration, a flat (bridged) network, where each VM’s IP is part of the same network as the Hypervisors.
 
-![image](/images/one_deploy_arch_local.png)
+![><](/images/one_deploy_arch_local.png)
 
 Throughout the tutorial we’ll use three server machines, please be sure to replace these references to your own IP addresses:
 
@@ -158,7 +158,7 @@ Below are sample contents for `example.yml`. You will probably need to modify pa
 all:
   vars:
     ansible_user: root
-    one_version: '6.10'
+    one_version: '{{< version >}}'
     one_pass: opennebulapass
     vn:
       admin_net:
@@ -428,7 +428,7 @@ The `STATE` column should display `rdy`.
 
 Next we can connect to the Sunstone UI on the Front-end. On any machine with connectivity to the Front-end node, point your browser to `<Front-end IP>:2616`, in this case `http://172.20.0.2:2616`. You should be greeted with the Sunstone login screen:
 
-![image](/images/sunstone_login_dark.png)
+![><](/images/sunstone_login_dark.png)
 <br/>
 
 You can log in as user `oneadmin`, with the password provided as the `one_pass` parameter in the `example.yml` file (in this example, `opennebulapass`).

--- a/content/software/installation_process/automatic_installation_with_onedeploy/one_deploy_tutorial_shared_ds.md
+++ b/content/software/installation_process/automatic_installation_with_onedeploy/one_deploy_tutorial_shared_ds.md
@@ -20,7 +20,7 @@ In this tutorial, we’ll use [OneDeploy](https://github.com/OpenNebula/one-depl
 
 This sample architecture uses a basic network configuration, a flat (bridged) network, where each VM’s IPs is part of the same network as the Hypervisors.
 
-![image](/images/one_deploy_arch_shared.png)
+![><](/images/one_deploy_arch_shared.png)
 
 Throughout the tutorial we’ll use three server machines, please be sure to replace these references to your own IP addresses:
 
@@ -187,7 +187,7 @@ Below are sample contents for `shared.yml`. You will probably need to modify par
 all:
   vars:
     ansible_user: root
-    one_version: '6.10'
+    one_version: '{{< version >}}'
     one_pass: opennebulapass
     vn:
       service:
@@ -486,7 +486,7 @@ The `STATE` column should display `rdy`.
 
 Next we can connect to the Sunstone UI on the Front-end. On any machine with connectivity to the Front-end node, point your browser to `<Front-end IP>:2616`, in this case `http://172.20.0.10:2616`. You should be greeted with the Sunstone login screen:
 
-![image](/images/sunstone_login_dark.png)
+![><](/images/sunstone_login_dark.png)
 <br/>
 
 You can log in as user `oneadmin`, with the password provided as the `one_pass` parameter in the `shared.yml` file (in this example, `opennebulapass`).


### PR DESCRIPTION
### Description

In the OneDeploy tutorials:

- Replace `6.10` in `one_version` to the `{< version >}}` variable
- Center images

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
