### PR TITLE
M #-: Remove no_list parameter from 2 index pages

### DIFF
--- a/content/product/cloud_system_administration/capacity_planning/_index.md
+++ b/content/product/cloud_system_administration/capacity_planning/_index.md
@@ -5,7 +5,6 @@ description: "Define resource usage and quotas by VMs, VM groups, and cloud user
 categories:
 pageintoc: "133"
 tags:
-no_list: "true"
 weight: "3"
 ---
 

--- a/content/product/cloud_system_administration/resource_monitoring/_index.md
+++ b/content/product/cloud_system_administration/resource_monitoring/_index.md
@@ -4,7 +4,6 @@ description: "Set up and configure the OpenNebula monitoring and resource usage 
 categories:
 pageintoc: ""
 tags:
-no_list: "true"
 weight: "5"
 ---
 


### PR DESCRIPTION
### Description

Remove `no_list: "true"` which is preventing generation of indexes in 2 pages.

This would apply to one-7.0 and master

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
