### PR TITLE
B OpenNebula/one#7059: OpenvSwitch.rb VXLAN failure add-port already exists on bridge

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -33,3 +33,4 @@ The following issues has been solved in 7.0.1:
 - Fix the `kvmrc` configuration file parser that was preventing more than one parameter [#7069](https://github.com/OpenNebula/one/issues/7069)
 - Fix react crash when accessing increments subtab for a backup image [#7173](https://github.com/OpenNebula/one/issues/7173)
 - Fix Sunstone should prioritize user views [#7082](https://github.com/OpenNebula/one/issues/7082)
+- Fix OpenvSwitch.rb VXLAN failure add-port already exists on bridge [#7059] (https://github.com/OpenNebula/one/issues/7059)


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->
Add resolved issue for: [OpenNebula/one#7059](https://github.com/OpenNebula/one/issues/7059)
### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-7.0-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
