### PR TITLE
F OpenNebula/engineering#381: update IONOS guide with adding a new host

### DIFF
--- a/content/solutions/hosted_cloud_providers/ionos_opennebula/ionos_auto_deploy_and_config.md
+++ b/content/solutions/hosted_cloud_providers/ionos_opennebula/ionos_auto_deploy_and_config.md
@@ -105,3 +105,12 @@ For detailed information about how to use the required parameters and which conf
 [ip-booked-for-server]: /images/solutions/ionos/ip-booked-for-server.png
 [token-manager]: /images/solutions/ionos/token-manager.png
 [dcd-uuid]: /images/solutions/ionos/dcd-uuid.png
+
+## Extending with a New Host
+
+During the operation of the hosted OpenNebula cloud, the deployment can be flexibly extended by adding new hosts. The extension procedure consists of these high-level steps:
+
+1. Provision the new host using the IONOS Data Center Designer as described in [Infrastructure Provisioning](#infrastructure-provisioning),
+1. Save the required parameters of the new host, as shown in [Save Required Parameters](#save-required-parameters),
+1. Re-execute the deployment and verification commands, as described in the [Deployment and Verification](#deployment-and-verification) section.
+

--- a/content/solutions/hosted_cloud_providers/ionos_opennebula/ionos_hw_spec_and_arch.md
+++ b/content/solutions/hosted_cloud_providers/ionos_opennebula/ionos_hw_spec_and_arch.md
@@ -12,7 +12,7 @@ This section describes the cloud architecture used in this guide, and provides t
 
 ## Architecture
 
-The target high-level cloud architecture overview is shown below. Two hosts are deployed: the first for hosting the OpenNebula Front-end services and VMs, the second for hosting VMs only. Both machines should have a public IP, which is used to manage the nodes. Additional public IPs are required to access running Virtual Machines. The proposed model connects VMs internally using VXLAN networks, with at least one VM assigned a public IP to act as a gateway, NATing traffic to and from the internal network.
+The target high-level cloud architecture overview is shown below. Two hosts are deployed: the first for hosting the OpenNebula Front-end services and VMs, the second for hosting VMs only. Both machines should have a public IP, which is used to manage the nodes. Additional public IPs are required to access running Virtual Machines. For internal networking between the VMs a VXLAN network is used, that is isolated from the public traffic.
 
 ![><][high-level]
 
@@ -55,4 +55,4 @@ The target high-level cloud architecture overview is shown below. Two hosts are 
 | NETWORK   |
 | :---- | :---- |
 | Networking | VXLAN, Public routed network |
-| Number of Networks | 2 networks: VXLAN  Public routed network, with each host machine having a NIC and a public IP |
+| Number of Networks | 2 networks: VXLAN  internal network, public network for external access |


### PR DESCRIPTION
### Description

It has been requested by cloud service providers to give a reference guide on how we currently recommend extending the OpenNebula deployment with a new host.
As discussed earlier with @tinova as an interim solution, we recommend using one-deploy to provision the new host (e.g. on IONOS cloud platform), add the new host to the Ansible inventory and re-execute the deployment automation.

This commit extends the IONOS reference CSP deployment guide with this recommendation. See testing references in the related issue. A corresponding section has been added to the IONOS deployment repo with reference to the actual commands: https://github.com/OpenNebula/hosted-cloud-ionos?tab=readme-ov-file#extending-with-a-new-host

Closes OpenNebula/engineering#381

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-7.0

<hr>

