### PR TITLE
SAN/LVM improvements

### DIFF
--- a/content/product/cluster_configuration/storage_system/lvm_drivers.md
+++ b/content/product/cluster_configuration/storage_system/lvm_drivers.md
@@ -49,7 +49,7 @@ First we need to configure hypervisors for LVM operations over the shared SAN st
 * All the nodes need to have access to the same LUNs.
 
 {{< alert title="Note" color="success" >}}
-In case of the virtualization Host reboot, the volumes need to be activated to be available for the hypervisor again. If the [node package]({{% relref "kvm_node_installation#kvm-node" %}}) is installed, the activation is done automatically. If not, each volume device of the Virtual Machines running on the Host before the reboot needs to be activated manually by running `lvchange -ay $DEVICE` (or, activation script `/var/tmp/one/tm/fs_lvm/activate` from the remote scripts may be executed on the Host to do the job).
+In case of the virtualization Host reboot, the volumes need to be activated to be available for the hypervisor again. If the [node package]({{% relref "kvm_node_installation#kvm-node" %}}) is installed, the activation is done automatically. If not, each volume device of the Virtual Machines running on the Host before the reboot needs to be activated manually by running `lvchange -ay $DEVICE` (or, activation script `/var/tmp/one/tm/fs_lvm_ssh/activate` from the remote scripts may be executed on the Host to do the job).
 {{< /alert >}}
 
 Virtual Machine disks are symbolic links to the block devices. However, additional VM files like checkpoints or deployment files are stored under `/var/lib/one/datastores/<id>`. Be sure that enough local space is present.
@@ -289,7 +289,7 @@ more info about the differences in thin and non-thin operation.
 
 ### Driver Configuration
 
-By default the LVM driver will zero any LVM volume so that VM data cannot leak to other instances. However, this process takes some time and may delay the deployment of a VM. The behavior of the driver can be configured in the file `/var/lib/one/remotes/etc/fs_lvm/fs_lvm.conf`, in particular:
+By default the LVM driver will zero any LVM volume so that VM data cannot leak to other instances. However, this process takes some time and may delay the deployment of a VM. The behavior of the driver can be configured in the file `/var/lib/one/remotes/etc/tm/fs_lvm/fs_lvm.conf`, in particular:
 
 | Attribute            | Description                                    |
 |----------------------|------------------------------------------------|

--- a/content/product/cluster_configuration/storage_system/lvm_drivers.md
+++ b/content/product/cluster_configuration/storage_system/lvm_drivers.md
@@ -291,11 +291,11 @@ more info about the differences in thin and non-thin operation.
 
 By default the LVM driver will zero any LVM volume so that VM data cannot leak to other instances. However, this process takes some time and may delay the deployment of a VM. The behavior of the driver can be configured in the file `/var/lib/one/remotes/etc/tm/fs_lvm/fs_lvm.conf`, in particular:
 
-| Attribute            | Description                                    |
-|----------------------|------------------------------------------------|
-| `ZERO_LVM_ON_CREATE` | Zero LVM volumes when they are created/resized |
-| `ZERO_LVM_ON_DELETE` | Zero LVM volumes when VM disks are deleted     |
-| `DD_BLOCK_SIZE`      | Block size for dd operations (default: 64kB)   |
+| Attribute              | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `ZERO_LVM_ON_CREATE`   | Zero LVM volumes when they are created/resized (default: yes) |
+| `ZERO_LVM_ON_DELETE`   | Zero LVM volumes when VM disks are deleted (default: yes)     |
+| `DD_BLOCK_SIZE`        | Block size for dd operations (default: 64kB)                  |
 
 Example:
 
@@ -310,13 +310,18 @@ ZERO_LVM_ON_DELETE=yes
 DD_BLOCK_SIZE=32M
 ```
 
+{{< alert title="Warning" color="warning" >}}
+Attributes related to disk zeroing (**ZERO_LVM_ON_\***) are ignored when LVM Thin mode is active. In this case, new volumes are always zeroed on creation.
+{{< /alert >}}
+
 The following attribute can be set for every datastore type:
 
 * `SUPPORTED_FS`: Comma-separated list with every filesystem supported for creating formatted datablocks. Can be set in `/var/lib/one/remotes/etc/datastore/datastore.conf`.
 * `FS_OPTS_<FS>`: Options for creating the filesystem for formatted datablocks. Can be set in `/var/lib/one/remotes/etc/datastore/datastore.conf` for each filesystem type.
 
 {{< alert title="Warning" color="warning" >}}
-Before adding a new filesystem to the `SUPPORTED_FS` list make sure that the corresponding `mkfs.<fs_name>` command is available in all Hosts including Front-end and hypervisors. If an unsupported FS is used by the user the default one will be used.{{< /alert >}}
+Before adding a new filesystem to the `SUPPORTED_FS` list make sure that the corresponding `mkfs.<fs_name>` command is available in all Hosts including Front-end and hypervisors. If an unsupported FS is used by the user the default one will be used.
+{{< /alert >}}
 
 <a id="datastore-internals"></a>
 

--- a/content/product/cluster_configuration/storage_system/overview.md
+++ b/content/product/cluster_configuration/storage_system/overview.md
@@ -40,23 +40,23 @@ There are different Image Datastores depending on how the images are stored on t
 
 Each datastore supports different features, here is a basic overview:
 
-|                                                                                                | [NFS/NAS]({{% relref "nas_ds#nas-ds" %}})   | [Local]({{% relref "local_ds#local-ds" %}})   | [Ceph]({{% relref "ceph_ds#ceph-ds" %}})   | [SAN]({{% relref "lvm_drivers#lvm-drivers" %}})   | [iSCSI]({{% relref "iscsi_ds#iscsi-ds" %}})   |
-|------------------------------------------------------------------------------------------------|----------------------------|------------------------------|---------------------------|----------------------------------|------------------------------|
-| Disk snapshots                                                                                 | yes                        | yes                          | yes                       | no                               | yes                          |
-| VM snapshots                                                                                   | yes                        | yes                          | no                        | no                               | no                           |
-| Live migration                                                                                 | yes                        | yes                          | yes                       | yes                              | yes                          |
-| Fault tolerance<br/>([VM HA]({{% relref "../../control_plane_configuration/high_availability/vm_ha#vm-ha" %}})) | yes                        | no                           | yes                       | yes                              | yes                          |
+|                                                                                                                 | [NFS/NAS]({{% relref "nas_ds#nas-ds" %}}) | [Local]({{% relref "local_ds#local-ds" %}}) | [Ceph]({{% relref "ceph_ds#ceph-ds" %}}) | [SAN]({{% relref "lvm_drivers#lvm-drivers" %}}) | [iSCSI]({{% relref "iscsi_ds#iscsi-ds" %}}) |
+| ------------------------------------------------------------------------------------------------                | ----------------------------              | ------------------------------              | ---------------------------              | ----------------------------------              | ------------------------------              |
+| Disk snapshots                                                                                                  | yes                                       | yes                                         | yes                                      | yes (LVM Thin only)                             | yes                                         |
+| VM snapshots                                                                                                    | yes                                       | yes                                         | no                                       | no                                              | no                                          |
+| Live migration                                                                                                  | yes                                       | yes                                         | yes                                      | yes                                             | yes                                         |
+| Fault tolerance<br/>([VM HA]({{% relref "../../control_plane_configuration/high_availability/vm_ha#vm-ha" %}})) | yes                                       | no                                          | yes                                      | yes                                             | yes                                         |
 
 {{< alert title="NetApp SAN Datastore (EE)" >}}
 
 The NetApp SAN Datastore is provided as an Enterprise Extension. Its basic features are listed below.
 
-|                          |     |
-|--------------------------|-----|
-| Disk snapshots           | yes |
-| VM snapshots             | no  |
-| Live migration           | yes |
-| Fault tolerance ([VM HA]({{% relref "../../control_plane_configuration/high_availability/vm_ha#vm-ha" %}})) | yes |
+| Feature                                                                                                     | Supported |
+| ----------------------------------------------------------------------------------------------------------- | --------- |
+| Disk snapshots                                                                                              | yes       |
+| VM snapshots                                                                                                | no        |
+| Live migration                                                                                              | yes       |
+| Fault tolerance ([VM HA]({{% relref "../../control_plane_configuration/high_availability/vm_ha#vm-ha" %}})) | yes       |
 
 {{< /alert >}}
 


### PR DESCRIPTION
### Description

Three improvements to LVM docs:
- Add disk snapshot support for SAN (LVM Thin only) to the table in overview
- SAN DS: fix reference to `fs_lvm` instead of `fs_lvm_ssh`
- SAN DS: add note about zeroing in LVM Thin (always on)

### Branches to which this PR applies


- [X] master
- [X] one-7.0

<hr>

- [ ] Check this if this PR should **not** be squashed
