### PR TITLE
F OpenNebula/One#7131: Way back to tables when create/update resource

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -45,3 +45,4 @@ The following issues has been solved in 7.0.1:
 - Fix upgrade for iconoir-react library [#6422](https://github.com/OpenNebula/one/issues/6422)
 - Fix performance issue in DRS scheduler [#7211](https://github.com/OpenNebula/one/issues/7211)
 - Fix race condition when monitor probes update VM status [#7058](https://github.com/OpenNebula/one/issues/7058)
+- Fix way back to tables when creating and updating resources [#7131](https://github.com/OpenNebula/one/issues/7131)


### PR DESCRIPTION
### Description

This PR adds the issue: Way back to tables when create/update resource in the resolver's problem file.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] one-7.0-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
