### PR TITLE
B OpenNebula/one#7231: Avoid Host not permitted on Sinatra server when is behind NGINX proxy

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -51,3 +51,4 @@ The following issues has been solved in 7.0.1:
 - Fix race condition when monitor probes update VM status [#7058](https://github.com/OpenNebula/one/issues/7058)
 - Fix way back to tables when creating and updating resources [#7131](https://github.com/OpenNebula/one/issues/7131)
 - Fix iptables flags to not use unsupported options (based on iptables version) [#7215](https://github.com/OpenNebula/one/issues/7215)
+- Fix `Host not permitted` error on Sinatra server when is behind from NGINX proxy [#7231](https://github.com/OpenNebula/one/issues/7231)


### PR DESCRIPTION
### Description

 Update resolved issues for version 7.0.1

<hr>

- [ ] Check this if this PR should **not** be squashed
