### PR TITLE
B OpenNebula/one-ee#6955: updated Ethernet text on Address Ranges

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -51,3 +51,4 @@ The following issues has been solved in 7.0.1:
 - Fix race condition when monitor probes update VM status [#7058](https://github.com/OpenNebula/one/issues/7058)
 - Fix way back to tables when creating and updating resources [#7131](https://github.com/OpenNebula/one/issues/7131)
 - Fix iptables flags to not use unsupported options (based on iptables version) [#7215](https://github.com/OpenNebula/one/issues/7215)
+- Fix Ethernet text on Address Ranges when create VMs [#6955](https://github.com/OpenNebula/one/issues/6955)


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->
Updated Ethernet text on Address Ranges when create VMs.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-7.0

<hr>

- [ ] Check this if this PR should **not** be squashed
