### PR TITLE
B OpenNebula/one#7239: OneGate does not update well VM user template when `--erase` is declared

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -57,3 +57,4 @@ The following issues has been solved in 7.0.1:
 - Fix re-arrange time orders when adding a scheduled action in Creating VMs. [#7031](https://github.com/OpenNebula/one/issues/7031)
 - Fix translation text when creating VMs [#7222](https://github.com/OpenNebula/one/issues/7222)
 - Fix opennebula-ovirtapi: Add LVM-thin incrementals to the Veeam integration [#7236](https://github.com/OpenNebula/one/issues/7236)
+- Fix OneGate does not update well VM user template when --erase is declared [#7239](https://github.com/OpenNebula/one/issues/7239)


### PR DESCRIPTION
### Description
Update resolved issues for version 7.0.1

<hr>

- [ ] Check this if this PR should **not** be squashed
