### PR TITLE
add platform notes for SAN storage

### DIFF
--- a/content/software/release_information/release_notes_70/platform_notes.md
+++ b/content/software/release_information/release_notes_70/platform_notes.md
@@ -74,6 +74,8 @@ More information: [one-apps wiki](https://github.com/OpenNebula/one-apps/wiki)
 | iSCSI       | Version included in the Linux distribution | [LVM Drivers]({{% relref "../../../product/cluster_configuration/storage_system/lvm_drivers#lvm-drivers" %}}) |
 | LVM2        | Version included in the Linux distribution | [LVM Drivers]({{% relref "../../../product/cluster_configuration/storage_system/lvm_drivers#lvm-drivers" %}}) |
 | Ceph        | Reef v18.2.x<br/>Squid   v19.2.x          | [The Ceph Datastore]({{% relref "../../../product/cluster_configuration/storage_system/ceph_ds#ceph-ds" %}})  |
+| NetApp      | ONTAP 9.16.1P1.                            | [NetApp ONTAP Drivers]({{% relref "../../../integrations/storage_extensions/netapp" %}}) |
+| LVM-thin    | NetApp ONTAP 9.16.1P1 & Pure Storage 6.7.2 | [LVM Thin]({{% relref "../../../product/cluster_configuration/storage_system/lvm_drivers#lvm-thin" %}}) |
 
 ### Authentication
 


### PR DESCRIPTION
### Description

Adds platform notes about NetApp and PureStorage both for the NetApp driver and the LVM-thin driver

### Branches to which this PR applies

- [x] one-7.0

<hr>

- [ ] Check this if this PR should **not** be squashed
