### PR TITLE
F OpenNebula/one#7261: Include per-host PCI device filtering

### DIFF
--- a/content/product/cluster_configuration/hosts_and_clusters/pci_passthrough.md
+++ b/content/product/cluster_configuration/hosts_and_clusters/pci_passthrough.md
@@ -229,7 +229,7 @@ The driver configuration file ( `/var/lib/one/remotes/etc/im/kvm-probes.d/pci.co
 | `PCI_FILTER`        | *(List)* Filters by PCI `vendor:device:class` patterns (same as for `lspci`)       |
 | `PCI_SHORT_ADDRESS` | *(List)* Filters by short PCI address `bus:device.function`                        |
 
-Example:
+Example: The command below filters by PCI with the `10de:*` pattern and addresses using the `e1` bus`
 ```default
 $ onehost show 0 | grep PCI
 PCI_FILTER="10de:*"


### PR DESCRIPTION
### Description

Include per-host PCI device filtering in documentation

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
