### PR TITLE
B OpenNebula/one#7252 remove tmp files after image creation

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -61,3 +61,4 @@ The following issues has been solved in 7.0.1:
 - Fix opennebula-ovirtapi: Add LVM-thin incremental backup to the Veeam integration [#7236](https://github.com/OpenNebula/one/issues/7236)
 - Fix fsck to update history ETIME using EETIME or RETIME [#7250](https://github.com/OpenNebula/one/issues/7250)
 - Fix update a VM configuration removes some attributes [#6987](https://github.com/OpenNebula/one/issues/6987)
+- Fix remove tmp files after creating Image [#7252](https://github.com/OpenNebula/one/issues/7252)


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->
Removed temporary files in /var/tmp after creating the Image

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] one-7.0 maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
