### PR TITLE
B OpenNebula/one#7107: Adds patch_datasources fix for ipv6 resolved issue

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -64,3 +64,4 @@ The following issues has been solved in 7.0.1:
 - Fix physical CPU tooltip in Sunstone [#6867](https://github.com/OpenNebula/one/issues/6867)
 - Fix update a VM configuration removes some attributes [#6987](https://github.com/OpenNebula/one/issues/6987)
 - Fix remove tmp files after creating Image [#7252](https://github.com/OpenNebula/one/issues/7252)
+- Fix prometheus patch_datasources.rb ipv6 addresses handling [#7107](https://github.com/OpenNebula/one/issues/7107)


### PR DESCRIPTION
### Description

Adds a new resolved issue to the 7.0.1 release notes (Prometheus `patch_datasources.rb` IPv6 addresses compatibility fix).

### Branches to which this PR applies

- [ ] one-7.0-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
