### PR TITLE
B OpenNebula/one#7092: RSYNC backup driver error Bitmap already exists

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -66,4 +66,4 @@ The following issues has been solved in 7.0.1:
 - Fix remove tmp files after creating Image [#7252](https://github.com/OpenNebula/one/issues/7252)
 - Fix prometheus patch_datasources.rb ipv6 addresses handling [#7107](https://github.com/OpenNebula/one/issues/7107)
 - Fix OneGate server error output [#7251](https://github.com/OpenNebula/one/issues/7251)
-- Fix RSYNC backup driver error [#7092](https://github.com/OpenNebula/one/issues/7092)
+- Fix incremental backups to cleanup not needed bitmaps [#7092](https://github.com/OpenNebula/one/issues/7092)

--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -66,3 +66,4 @@ The following issues has been solved in 7.0.1:
 - Fix remove tmp files after creating Image [#7252](https://github.com/OpenNebula/one/issues/7252)
 - Fix prometheus patch_datasources.rb ipv6 addresses handling [#7107](https://github.com/OpenNebula/one/issues/7107)
 - Fix OneGate server error output [#7251](https://github.com/OpenNebula/one/issues/7251)
+- Fix RSYNC backup driver error [#7092](https://github.com/OpenNebula/one/issues/7092)


### PR DESCRIPTION
### Description

Updates resolved issues for [#7092](https://github.com/OpenNebula/one/issues/7092)

<!--- Please leave a helpful description of the PR here. --->

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] one-7.0-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
