### PR TITLE
B OpenNebula/one#7202: Sunstone drop Context when create VM from Template

### DIFF
--- a/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
+++ b/content/software/release_information/release_notes_enterprise/resolved_issues_701.md
@@ -81,3 +81,4 @@ The following issues has been solved in 7.0.1:
 - Fix history ETIME after resize, disk-resize and pci-(de)attach for VMs in undeployed state. [#7249](https://github.com/OpenNebula/one/issues/7249)
 - Fix DRS timeout for VM poweroff migrate. [#7224](https://github.com/OpenNebula/one/issues/7224)
 - Fix wrong QCOW2_STANDALONE option in NFS System Datastore . [#7212](https://github.com/OpenNebula/one/issues/7212)
+- Fix Sunstone drop Context when create VM from Template [#7202](https://github.com/OpenNebula/one/issues/7202)


### PR DESCRIPTION
### Description

Update resolved issues for version 7.0.1

