### PR TITLE
F OpenNebula/one#7487: Add option LOG_RESULT_LENGTH to oned.conf

### DIFF
--- a/content/product/operation_references/opennebula_services_configuration/oned.md
+++ b/content/product/operation_references/opennebula_services_configuration/oned.md
@@ -205,6 +205,7 @@ For showback the CPU and memory cost are counted if the resource is reserved on 
   - `%G` – group name
   - `%a` – auth token
   - `%%` – %
+- `LOG_RESULT_LENGTH`: Max length of the API result log length, default is 20.
 
 ```default
 #*******************************************************************************
@@ -219,6 +220,7 @@ For showback the CPU and memory cost are counted if the resource is reserved on 
 #RPC_LOG            = NO
 #MESSAGE_SIZE       = 1073741824
 #LOG_CALL_FORMAT    = "Req:%i UID:%u %m invoked %l"
+#LOG_RESULT_LENGTH  = 20
 ```
 
 ## Virtual Networks

--- a/content/software/release_information/release_notes/whats_new.md
+++ b/content/software/release_information/release_notes/whats_new.md
@@ -14,6 +14,7 @@ The OpenNebula team is excited to announce the availability of the **OpenNebula 
 
 
 ## OpenNebula Core
+* Add option [`LOG_RESULT_LENGTH` to `oned.conf`](../../../product/operation_references/opennebula_services_configuration/oned#xml-rpc-server-configuration) to configure max length of API result log.
 
 ## Storage & Backups
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-7.2 ? the line from `what's new` should be moved to resolved_issues

<hr>

- [ ] Check this if this PR should **not** be squashed
