### PR TITLE
Add known issue for RHEL9 nodejs conflict on 7.0→7.2 upgrade

### DIFF
--- a/content/software/release_information/release_notes/known_issues.md
+++ b/content/software/release_information/release_notes/known_issues.md
@@ -48,6 +48,15 @@ This page will be updated with relevant information about bugs affecting OpenNeb
     default: []
   ```
 
+## Upgrade
+
+- On RHEL/AlmaLinux 9, upgrading from OpenNebula 7.0 to 7.2 may fail due to conflicts between the distro nodejs 16 packages and the nodesource nodejs 20 required by `opennebula-fireedge`. The workaround is to remove the distro nodejs packages before upgrading:
+
+  ```default
+  rpm -e --nodeps nodejs nodejs-docs nodejs-full-i18n nodejs-libs npm
+  yum upgrade opennebula
+  ```
+
 ## Install Linux Graphical Desktop on KVM Virtual Machines
 
 OpenNebula uses the `cirrus` graphical adapter for KVM Virtual Machines by default. It could happen that after installing a graphical desktop on a Linux VM, the Xorg window system does not load the appropriate video driver. You can force a VESA mode by configuring the kernel parameter `vga=VESA_MODE` in the GNU GRUB configuration file. [Here](https://en.wikipedia.org/wiki/VESA_BIOS_Extensions#Linux_video_mode_numbers/) you can find the VESA mode numbers. For example, adding `vga=791` as kernel parameter will select the 16-bit 1024×768 resolution mode.

--- a/content/software/upgrade_process/upgrade_guide/upgrading_single.md
+++ b/content/software/upgrade_process/upgrade_guide/upgrading_single.md
@@ -75,6 +75,9 @@ apt-get install --only-upgrade opennebula opennebula-gate opennebula-flow openne
 
 RHEL
 
+{{< alert title="Warning" type="warning" >}}
+On RHEL/AlmaLinux 9, upgrading from OpenNebula 7.0 to 7.2 may fail due to conflicts between the distro nodejs 16 packages and the nodesource nodejs 20 required by `opennebula-fireedge`. Please check the [Known Issues]({{% relref "../../release_information/release_notes/known_issues#upgrade" %}}) for the workaround.{{< /alert >}}
+
 ```bash
 yum upgrade opennebula opennebula-gate opennebula-flow opennebula-fireedge opennebula-migration python3-pyone
 ```


### PR DESCRIPTION
- Adds known issue entry for RHEL/AlmaLinux 9 nodejs package conflicts when upgrading from 7.0 to 7.2
- Adds warning box in the single front-end upgrade guide (Step 6) linking to the known issue