### PR TITLE
F OpenNebula/one#7630: Update backup system overview table

### DIFF
--- a/content/product/cluster_configuration/backup_system/overview.md
+++ b/content/product/cluster_configuration/backup_system/overview.md
@@ -35,7 +35,7 @@ Finally, if you need to backup a large number of VMs you can manage them [effect
 
 ## Hypervisor and Storage Compatibility
 
-Performing a VM backup requires support from the hypervisor or the disk image formats. The following table summarizes the backup modes supported for each hypervisor and storage system.
+Performing a VM backup requires support from the hypervisor and the disk image formats. The following table summarizes the backup modes supported for each hypervisor and storage system.
 
 | **Hypervisor** | **Storage** | **Live (full)** | **Power off (full)** | **Live (incremental)** | **Power off (incremental)** |
 | --- | --- | --- | --- | --- | --- |

--- a/content/product/cluster_configuration/backup_system/overview.md
+++ b/content/product/cluster_configuration/backup_system/overview.md
@@ -12,119 +12,45 @@ weight: "1"
 
 <!--# Overview -->
 
-Here you will find details on how to configure the available backends for [Virtual Machine Backups](../../virtual_machines_operation/virtual_machine_backups/). Backups are managed through the datastore and image abstractions, so all of the concepts that apply to these objects, such as access control or quotas, are applicable to backups.
+Here you will find details on how to configure the available backends for [Virtual Machine Backups]({{% relref "product/virtual_machines_operation/virtual_machine_backups/" %}}). Backups are managed through the datastore and image abstractions, so all of the concepts that apply to these objects, such as access control or quotas, are applicable to backups.
 
 Define backup datastores by using the available options for backends or datastore drivers:
 
-- Restic: based on the [restic backup tool](https://restic.net/)
-- Rsync: relies on the [rsync utility](https://rsync.samba.org/) to transfer backup files.
-- OpenNebula-Veeam&reg; Backup Integration: provides robust, agentless backup and recovery for OpenNebula VMs using Veeam Backup & Replication.
+- **Restic**: Based on the [restic backup tool](https://restic.net/).
+- **Rsync**: Relies on the [rsync utility](https://rsync.samba.org/) to transfer backup files.
+- **OpenNebula-Veeam&reg; Backup Integration**: Provides robust, agentless backup and recovery for OpenNebula VMs using Veeam Backup & Replication.
 
 ## Basic Guide Outline
 
-Before reading this guide, you should have installed your [Frontend]({{% relref "frontend_install" %}}), the [KVM Hosts]({{% relref "kvm_node_installation#kvm-node" %}}) and have an OpenNebula cloud up and running with at least one virtualization node.
+Before reading this guide, you should have installed your [Front-end]({{% relref "frontend_install" %}}), the [KVM Hosts]({{% relref "kvm_node_installation#kvm-node" %}}) and have an OpenNebula cloud up and running with at least one virtualization node.
 
 To configure your backup system, find about datastore driver options to save your VM backups:
 * [Restic backend]({{% relref "restic#vm-backups-restic" %}}) 
 * [Rsync datastore]({{% relref "rsync#vm-backups-rsync" %}})
 * [OpenNebula-Veeam Backup Integration]({{% relref "veeam#vm-backups-veeam" %}})
 
-Then, consult the [Virtual Machines Operation]({{% relref "../../virtual_machines_operation/virtual_machine_backups/operations" %}}) section to find out how to perform, schedule and restore VM backups.
+Then, consult the [Virtual Machines Operation]({{% relref "product/virtual_machines_operation/virtual_machine_backups/operations" %}}) section to find out how to perform, schedule and restore VM backups.
 
-Finally, if you need to backup a large number of VMs you can manage them [effectively through Backup Jobs]({{% relref "../../virtual_machines_operation/virtual_machine_backups/backup_jobs" %}}).
+Finally, if you need to backup a large number of VMs you can manage them [effectively through Backup Jobs]({{% relref "product/virtual_machines_operation/virtual_machine_backups/backup_jobs" %}}).
 
 ## Hypervisor and Storage Compatibility
 
 Performing a VM backup requires support from the hypervisor or the disk image formats. The following table summarizes the backup modes supported for each hypervisor and storage system.
 
-<!-- Markdown doesn't support merged cells in tables, so as a temporary workaround these are inserted in HTML -->
-
-<table class="docutils align-default">
-<thead>
-<tr class="row-odd">
-    <th class="head" rowspan="2"><p>Hypervisor</p></th>
-    <th class="head" rowspan="2"><p>Storage</p></th>
-    <th class="head" colspan="2"><p>Full</p></th>
-    <th class="head" colspan="2"><p>Incremental</p></th>
-</tr>
-<tr class="row-even">
-    <th class="head"><p>Live</p></th>
-    <th class="head"><p>Power off</p></th>
-    <th class="head"><p>Live</p></th>
-    <th class="head"><p>Power off</p></th>
-</tr>
-</thead>
-<tbody>
-<tr class="row-odd">
-    <td rowspan="5"><p>KVM</p></td>
-    <td><p>File<sup>*</sup> (qcow2)</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-</tr>
-<tr class="row-even">
-    <td><p>File<sup>*</sup> (raw)</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-    <td><p>No</p></td>
-    <td><p>No</p></td>
-</tr>
-<tr class="row-odd">
-    <td><p>Ceph</p></td>
-    <td><p>Yes<sup>†</sup></p></td>
-    <td><p>Yes<sup>†</sup>
-    <td><p>Yes<sup>†</sup>
-    <td><p>Yes<sup>†</sup>
-</tr>
-<tr class="row-even">
-    <td><p>LVM</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-</tr>
-<tr class="row-odd">
-    <td><p>LVM (File Mode)</p></td>
-    <td><p>Yes<sup>‡</sup></p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes<sup>‡</sup></p></td>
-    <td><p>Yes<sup>‡</sup></p></td>
-</tr>
-<tr class="row-even">
-    <td rowspan="4"><p>LXC</p></td>
-    <td><p>File (any format)</p></td>
-    <td><p>No</p></td>
-    <td><p>Yes</p></td>
-    <td><p>No</p></td>
-    <td><p>No</p></td>
-</tr>
-<tr class="row-odd">
-    <td><p>Ceph</p></td>
-    <td><p>No</p></td>
-    <td><p>Yes</p></td>
-    <td><p>No</p></td>
-    <td><p>No</p></td>
-</tr>
-<tr class="row-even">
-    <td><p>LVM</p></td>
-    <td><p>Yes</p></td>
-    <td><p>Yes</p></td>
-    <td><p>No</p></td>
-    <td><p>No</p></td>
-</tr>
-<tr class="row-odd">
-    <td><p>LVM (File Mode)</p></td>
-    <td><p>Yes<sup>‡</sup></p></td>
-    <td><p>Yes</p></td>
-    <td><p>No</p></td>
-    <td><p>No</p></td>
-</tr>
-</tbody>
-</table>
+| **Hypervisor** | **Storage** | **Live (full)** | **Power off (full)** | **Live (incremental)** | **Power off (incremental)** |
+| --- | --- | --- | --- | --- | --- |
+| **KVM** | File\* (qcow2) | Yes | Yes | Yes | Yes |
+| | File\* (raw) | Yes | Yes | No  | No  |
+| | Ceph | Yes<sup><strong>†</strong></sup>  | Yes<sup><strong>†</strong></sup>  | Yes<sup><strong>†</strong></sup> | Yes<sup><strong>†</strong></sup>  |
+| | LVM | Yes | Yes | Yes | Yes |
+| | LVM (File Mode) | Yes<sup><strong>‡</strong></sup> | Yes | Yes<sup><strong>‡</strong></sup> | Yes<sup><strong>‡</strong></sup> |
+| **LXC** | File (any format) | No  | Yes | No  | No  |
+| | Ceph | No  | Yes | No  | No  |
+| | LVM | Yes | Yes | No  | No  |
+| | LVM (File Mode) | Yes<sup><strong>‡</strong></sup> | Yes | No  | No  |
 
 <sup>\*</sup> Any datastore based on files with the given format, i.e. NFS/SAN or Local.
 
-<sup>†</sup> Ceph full and incremental backups are currently stored in a different way, see [backup types]({{% relref "../../virtual_machines_operation/virtual_machine_backups/operations#backup-types" %}}) for more details.
+<sup>†</sup> Ceph full and incremental backups are currently stored in a different way, see [backup types]({{% relref "product/virtual_machines_operation/virtual_machine_backups/operations#backup-types" %}}) for more details.
 
-<sup>‡</sup> Only supported in [thin mode]({{% relref "../../../product/cluster_configuration/lvm/filemode#lvm-thin" %}}).
+<sup>‡</sup> Only supported in [thin mode]({{% relref "product/cluster_configuration/lvm/filemode#lvm-thin" %}}).


### PR DESCRIPTION
### Description

The table in the [Backup System Overview](https://docs.opennebula.io/7.2/product/cluster_configuration/backup_system/overview/) has been converted from HTML to markdown to better match other tables in the documentation in terms of style.

Original:
<img width="1484" height="1008" alt="image" src="https://github.com/user-attachments/assets/0357d911-6ecb-4c3f-b23c-a9c587c576ac" />

Fixed:
<img width="1484" height="1008" alt="image" src="https://github.com/user-attachments/assets/c29ef13b-81e3-4c18-9d88-58a627aa6341" />

### Branches to which this PR applies

- [x] master
- [x] one-7.2
- [x] one-7.2-maintenance
