### PR TITLE
F OpenNebula/one#7652: Added custom 404 response page

### DIFF
--- a/assets/scss/error/_styles_project_404.scss
+++ b/assets/scss/error/_styles_project_404.scss
@@ -1,0 +1,7 @@
+@import "../_styles_fonts";
+
+.error-page-container {
+    width: 100%;
+    max-width: none; /* Overrides constraints */
+    background-color: #f8f9fa; /* Ensure the color fills the area */
+}

--- a/assets/scss/error/_styles_project_404.scss
+++ b/assets/scss/error/_styles_project_404.scss
@@ -1,7 +1,0 @@
-@import "../_styles_fonts";
-
-.error-page-container {
-    width: 100%;
-    max-width: none; /* Overrides constraints */
-    background-color: #f8f9fa; /* Ensure the color fills the area */
-}

--- a/layouts/_default/404.html
+++ b/layouts/_default/404.html
@@ -1,0 +1,23 @@
+{{ define "main" }}
+<div class="td-content">
+    <h1>404: Page Not Found</h1>
+    <p>The documentation for OpenNebula has been restructured. It's likely that the page you are looking for has moved.</p>
+    
+    <div class="alert alert-primary" role="alert">
+        <strong>Try these principal sections:</strong>
+    </div>
+
+    <ul>
+        {{/* Update these strings to the exact relative paths in your content folder */}}
+        {{ $paths := slice "software/installation_process/" "software/installation_process/" }}
+        {{ range $paths }}
+            {{ with $.Site.GetPage . }}
+                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+            {{ else }}
+                {{/* This ensures you catch broken links during the build */}}
+                {{ errorf "404 Page: Link path not found: %s" . }}
+            {{ end }}
+        {{ end }}
+    </ul>
+</div>
+{{ end }}

--- a/layouts/_default/404.html
+++ b/layouts/_default/404.html
@@ -1,23 +1,33 @@
 {{ define "main" }}
-<div class="td-content">
-    <h1>404: Page Not Found</h1>
-    <p>The documentation for OpenNebula has been restructured. It's likely that the page you are looking for has moved.</p>
-    
-    <div class="alert alert-primary" role="alert">
-        <strong>Try these principal sections:</strong>
-    </div>
+<style>
+    @media (min-width: 1200px) {
+        .td-404 [role=main] {
+            width: 100% !important; /* Full width (10/12 columns) */
+            max-width: none !important;
+            margin-right: 0 !important;
+        }
+    }
+</style>
+<div class="row flex-xl-nowrap" style="width:100%">
+    <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
+        
+        <div class="td-content">
+            <h1>Page Not Found</h1>
+            <p>The documentation for OpenNebula is regularly updated. It's possible that the page you are looking for has moved.</p>
+            <p>You may find what you are looking for in one of the following sections:</p>
 
-    <ul>
-        {{/* Update these strings to the exact relative paths in your content folder */}}
-        {{ $paths := slice "software/installation_process/" "software/installation_process/" }}
-        {{ range $paths }}
-            {{ with $.Site.GetPage . }}
-                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-            {{ else }}
-                {{/* This ensures you catch broken links during the build */}}
-                {{ errorf "404 Page: Link path not found: %s" . }}
-            {{ end }}
-        {{ end }}
-    </ul>
+            <ul>
+                {{ $paths := slice "getting_started/" "product/" "software/installation_process/" "software/release_information/" "solutions/"}}
+                {{ range $paths }}
+                    {{ with $.Site.GetPage . }}
+                        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+                    {{ else }}
+                        {{/* Validation check */}}
+                        {{ errorf "404 Page: Link path not found: %s" . }}
+                    {{ end }}
+                {{ end }}
+            </ul>
+        </div>
+    </main>
 </div>
 {{ end }}

--- a/layouts/_default/404.html
+++ b/layouts/_default/404.html
@@ -1,12 +1,10 @@
 {{ define "main" }}
 <style>
-    @media (min-width: 1200px) {
-        .td-404 [role=main] {
-            width: 100% !important; /* Full width (10/12 columns) */
-            max-width: none !important;
-            margin-right: 0 !important;
-        }
-    }
+.td-404 [role=main] {
+    width: 100% !important; /* Full width (10/12 columns) */
+    max-width: none !important;
+    margin-right: 0 !important;
+}
 </style>
 <div class="row flex-xl-nowrap" style="width:100%">
     <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
@@ -17,7 +15,10 @@
             <p>You may find what you are looking for in one of the following sections:</p>
 
             <ul>
-                {{ $paths := slice "getting_started/" "product/" "software/installation_process/" "software/release_information/" "solutions/"}}
+                <li>
+                    <a href="{{ .Site.BaseURL }}/">Documentation Home</a>
+                </li>
+                {{ $paths := slice "getting_started/" "product/" "software/installation_process/" "software/upgrade_process/" "software/release_information/" "solutions/"}}
                 {{ range $paths }}
                     {{ with $.Site.GetPage . }}
                         <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>


### PR DESCRIPTION
### Description

This PR introduces a custom 404 response page which retains OpenNebula branding and Docs layout, plus the nav bar and some link suggestions such that the user can more easily find the documentation they were looking for. It also gives a more professional appearence.

### Branches to which this PR applies

- [x] master
- [x] one-7.2
- [x] one-7.2-maintenance
