### PR TITLE
F OpenNebula/one#7635: Add anchor links to all headings

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -14,6 +14,7 @@
 @import "image/_styles_project_image.scss";
 @import "dashboard/_styles_project_dashboard.scss";
 @import "search-docs/_styles_project_search_docs.scss";
+@import "heading/styles_project_heading.scss";
 @import "_styles_fonts";
 
 /**

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -71,53 +71,6 @@ $card-columns-gap: 10px !important;
 $card-spacer-y: 10px;
 $card-spacer-x: 10px;
 
-// Anchor link styles for headings (h1-h6)
-.anchor-link {
-  visibility: hidden !important;
-  opacity: 0;
-  margin-left: 0.5rem;
-  color: rgba(0, 0, 0, 0.3); /* Light grey icon */
-  font-size: 0.7em;
-  vertical-align: middle;
-  text-decoration: none !important;
-  transition: opacity 0.2s ease-in-out;
-}
-
-// Hover State: Reveal when the heading (h1-h6) is hovered
-h1:hover .anchor-link,
-h2:hover .anchor-link,
-h3:hover .anchor-link,
-h4:hover .anchor-link,
-h5:hover .anchor-link,
-h6:hover .anchor-link {
-  visibility: visible !important;
-  opacity: 1;
-}
-
-// 3. Active Hover: Change color when mousing directly over the icon
-.anchor-link:hover {
-  color: #007bff !important; /* Your primary brand color */
-}
-
-// Dark Mode: Overrides based on your data attribute and media query
-html[data-bs-theme="dark"] .anchor-link {
-    color: rgba(255, 255, 255, 0.3); /* Subtle white when revealed */
-}
-
-html[data-bs-theme="dark"] .anchor-link:hover {
-    color: #4dabff !important; /* Brighter blue for high contrast */
-}
-
-/// Optional: Fallback for system-level dark mode if the attribute isn't set yet
-@media (prefers-color-scheme: dark) {
-    html:not([data-bs-theme="light"]) .anchor-link {
-        color: rgba(255, 255, 255, 0.3);
-    }
-    html:not([data-bs-theme="light"]) .anchor-link:hover {
-        color: #4dabff !important;
-    }
-}
-
 
 
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -71,6 +71,53 @@ $card-columns-gap: 10px !important;
 $card-spacer-y: 10px;
 $card-spacer-x: 10px;
 
+// Anchor link styles for headings (h1-h6)
+.anchor-link {
+  visibility: hidden !important;
+  opacity: 0;
+  margin-left: 0.5rem;
+  color: rgba(0, 0, 0, 0.3); /* Light grey icon */
+  font-size: 0.7em;
+  vertical-align: middle;
+  text-decoration: none !important;
+  transition: opacity 0.2s ease-in-out;
+}
+
+// Hover State: Reveal when the heading (h1-h6) is hovered
+h1:hover .anchor-link,
+h2:hover .anchor-link,
+h3:hover .anchor-link,
+h4:hover .anchor-link,
+h5:hover .anchor-link,
+h6:hover .anchor-link {
+  visibility: visible !important;
+  opacity: 1;
+}
+
+// 3. Active Hover: Change color when mousing directly over the icon
+.anchor-link:hover {
+  color: #007bff !important; /* Your primary brand color */
+}
+
+// Dark Mode: Overrides based on your data attribute and media query
+html[data-bs-theme="dark"] .anchor-link {
+    color: rgba(255, 255, 255, 0.3); /* Subtle white when revealed */
+}
+
+html[data-bs-theme="dark"] .anchor-link:hover {
+    color: #4dabff !important; /* Brighter blue for high contrast */
+}
+
+/// Optional: Fallback for system-level dark mode if the attribute isn't set yet
+@media (prefers-color-scheme: dark) {
+    html:not([data-bs-theme="light"]) .anchor-link {
+        color: rgba(255, 255, 255, 0.3);
+    }
+    html:not([data-bs-theme="light"]) .anchor-link:hover {
+        color: #4dabff !important;
+    }
+}
+
 
 
 

--- a/assets/scss/heading/_styles_project_heading.scss
+++ b/assets/scss/heading/_styles_project_heading.scss
@@ -1,0 +1,84 @@
+// // Anchor link styles for headings (h1-h6)
+// .anchor-link {
+//   visibility: hidden !important;
+//   opacity: 0;
+//   margin-left: 0.5rem;
+//   color: rgba(0, 0, 0, 0.3); /* Light grey icon */
+//   font-size: 0.7em;
+//   vertical-align: middle;
+//   text-decoration: none !important;
+//   transition: opacity 0.2s ease-in-out;
+// }
+
+// // Hover State: Reveal when the heading (h1-h6) is hovered
+// h1:hover .anchor-link,
+// h2:hover .anchor-link,
+// h3:hover .anchor-link,
+// h4:hover .anchor-link,
+// h5:hover .anchor-link,
+// h6:hover .anchor-link {
+//   visibility: visible !important;
+//   opacity: 1;
+// }
+
+// // Active Hover: Change color when mousing directly over the icon
+// .anchor-link:hover {
+//   color: #007bff !important; /* Your primary brand color */
+// }
+
+// // Dark Mode: Overrides based on your data attribute and media query
+// html[data-bs-theme="dark"] .anchor-link {
+//     color: rgba(255, 255, 255, 0.3); /* Subtle white when revealed */
+// }
+
+// html[data-bs-theme="dark"] .anchor-link:hover {
+//     color: #4dabff !important; /* Brighter blue for high contrast */
+// }
+
+// /// Optional: Fallback for system-level dark mode if the attribute isn't set yet
+// @media (prefers-color-scheme: dark) {
+//     html:not([data-bs-theme="light"]) .anchor-link {
+//         color: rgba(255, 255, 255, 0.3);
+//     }
+//     html:not([data-bs-theme="light"]) .anchor-link:hover {
+//         color: #4dabff !important;
+//     }
+// }
+
+/* Use a more specific selector to ensure it beats theme defaults */
+.td-content {
+    .anchor-link {
+        visibility: hidden !important;
+        opacity: 0 !important;
+        margin-left: 0.4rem;
+        font-size: 0.8em;
+        text-decoration: none !important;
+        transition: opacity 0.2s ease-in-out, color 0.2s ease;
+        
+        /* Light mode default color */
+        color: rgba(0, 0, 0, 0.3) !important;
+    }
+
+    /* Target headers explicitly within the content area */
+    h1, h2, h3, h4, h5, h6 {
+        &:hover .anchor-link {
+            visibility: visible !important;
+            opacity: 1 !important;
+        }
+    }
+
+    /* Hover state for the link itself */
+    .anchor-link:hover {
+        color: #007bff !important; 
+    }
+}
+
+/* Dark Mode handling using the attribute you found */
+html[data-bs-theme="dark"] .td-content {
+    .anchor-link {
+        color: rgba(255, 255, 255, 0.3) !important;
+    }
+    .anchor-link:hover {
+        color: #4dabff !important;
+    }
+}

--- a/assets/scss/heading/_styles_project_heading.scss
+++ b/assets/scss/heading/_styles_project_heading.scss
@@ -1,51 +1,4 @@
-// // Anchor link styles for headings (h1-h6)
-// .anchor-link {
-//   visibility: hidden !important;
-//   opacity: 0;
-//   margin-left: 0.5rem;
-//   color: rgba(0, 0, 0, 0.3); /* Light grey icon */
-//   font-size: 0.7em;
-//   vertical-align: middle;
-//   text-decoration: none !important;
-//   transition: opacity 0.2s ease-in-out;
-// }
-
-// // Hover State: Reveal when the heading (h1-h6) is hovered
-// h1:hover .anchor-link,
-// h2:hover .anchor-link,
-// h3:hover .anchor-link,
-// h4:hover .anchor-link,
-// h5:hover .anchor-link,
-// h6:hover .anchor-link {
-//   visibility: visible !important;
-//   opacity: 1;
-// }
-
-// // Active Hover: Change color when mousing directly over the icon
-// .anchor-link:hover {
-//   color: #007bff !important; /* Your primary brand color */
-// }
-
-// // Dark Mode: Overrides based on your data attribute and media query
-// html[data-bs-theme="dark"] .anchor-link {
-//     color: rgba(255, 255, 255, 0.3); /* Subtle white when revealed */
-// }
-
-// html[data-bs-theme="dark"] .anchor-link:hover {
-//     color: #4dabff !important; /* Brighter blue for high contrast */
-// }
-
-// /// Optional: Fallback for system-level dark mode if the attribute isn't set yet
-// @media (prefers-color-scheme: dark) {
-//     html:not([data-bs-theme="light"]) .anchor-link {
-//         color: rgba(255, 255, 255, 0.3);
-//     }
-//     html:not([data-bs-theme="light"]) .anchor-link:hover {
-//         color: #4dabff !important;
-//     }
-// }
-
-/* Use a more specific selector to ensure it beats theme defaults */
+// Styles for heading anchor links (h1-h6)
 .td-content {
     .anchor-link {
         visibility: hidden !important;
@@ -73,7 +26,7 @@
     }
 }
 
-/* Dark Mode handling using the attribute you found */
+// Dark mode overrides
 html[data-bs-theme="dark"] .td-content {
     .anchor-link {
         color: rgba(255, 255, 255, 0.3) !important;

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,6 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">
+  {{ .Text | safeHTML }}
+  <a class="anchor-link" href="#{{ .Anchor | safeURL }}" aria-label="Link to this section">
+    <i class="fas fa-link fa-xs"></i>
+  </a>
+</h{{ .Level }}>


### PR DESCRIPTION
### Description

This PR introduces an anchor link for headings of all levels, such that developers can easily send clients links to specific documentation sections, including those that are below the heading level displayed in the right hand TOC. 

<img width="1729" height="821" alt="image" src="https://github.com/user-attachments/assets/504a02d5-2cbe-4858-93a6-7d429f229a88" />

### Branches to which this PR applies

- [x] master
- [x] one-7.2
- [x] one-7.2-maintenance
