### PR TITLE
F OpenNebula/one#7652: Custom 404 for 7.0 docs

### DIFF
--- a/layouts/_default/404.html
+++ b/layouts/_default/404.html
@@ -1,0 +1,34 @@
+{{ define "main" }}
+<style>
+.td-404 [role=main] {
+    width: 100% !important; /* Full width (10/12 columns) */
+    max-width: none !important;
+    margin-right: 0 !important;
+}
+</style>
+<div class="row flex-xl-nowrap" style="width:100%">
+    <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
+        
+        <div class="td-content">
+            <h1>Page Not Found</h1>
+            <p>The documentation for OpenNebula is regularly updated. It's possible that the page you are looking for has moved.</p>
+            <p>You may find what you are looking for in one of the following sections:</p>
+
+            <ul>
+                <li>
+                    <a href="{{ .Site.BaseURL }}/">Documentation Home</a>
+                </li>
+                {{ $paths := slice "getting_started/" "product/" "software/installation_process/" "software/upgrade_process/" "software/release_information/" "solutions/"}}
+                {{ range $paths }}
+                    {{ with $.Site.GetPage . }}
+                        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+                    {{ else }}
+                        {{/* Validation check */}}
+                        {{ errorf "404 Page: Link path not found: %s" . }}
+                    {{ end }}
+                {{ end }}
+            </ul>
+        </div>
+    </main>
+</div>
+{{ end }}


### PR DESCRIPTION
### Description

This PR introduces a custom 404.html not found response page for broken links for the 7.0 documentation.

### Branches to which this PR applies

- [x] one-7.0
- [x] one-7.0-maintenance
