### PR TITLE
B OpenNebula/one#7403: Fix Restic exclusive lock handling

### DIFF
--- a/content/software/release_information/release_notes/resolved_issues_721.md
+++ b/content/software/release_information/release_notes/resolved_issues_721.md
@@ -35,4 +35,5 @@ The following issues have been solved in 7.2.1:
 * Fix translations in other languages [#7365](https://github.com/OpenNebula/one/issues/7365).
 * Fix empty `PROBES_PERIOD` values causing monitor probes to run without delay [#7659](https://github.com/OpenNebula/one/issues/7659).
 * Fix an issue that could cause VLAN trunk information in Virtual Networks to become inconsistent after updating network attributes, resulting in incorrect `VLAN_TAGGED_ID` values being propagated to VM NICs. [#7654](https://github.com/OpenNebula/one/issues/7654).
-* Fix pure LVM live migration when VM has no CONTEXT [#7674](https://github.com/OpenNebula/one/issues/7674)
+* Fix pure LVM live migration when VM has no CONTEXT [#7674](https://github.com/OpenNebula/one/issues/7674).
+* Fix Restic exclusive lock detection [#7403](https://github.com/OpenNebula/one/issues/7403).


### PR DESCRIPTION
### Description

Documents issue https://github.com/OpenNebula/one/issues/7403

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [X] one-7.2-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
