### PR TITLE
F OpenNebula/engineering#824 add OneSwap delta migration known issue

### DIFF
--- a/content/software/release_information/release_notes/known_issues.md
+++ b/content/software/release_information/release_notes/known_issues.md
@@ -151,6 +151,6 @@ RAW=[
 
 ## OneSwap 
 
-OneSwap delta migration may fail on vCenter/ESXi 8 and newer because the sesparse tool used to apply VMware seSparse snapshot deltas was tested against older vCenter/ESXi versions.
+OneSwap delta migration may fail on vCenter/ESXi versions 8 and newer because the sesparse tool used to apply VMware SEsparse snapshot deltas was tested against older vCenter/ESXi versions.
 
-Until the upstream fix is merged, `sesparse` needs to be recompiled with the patch from [storpool/any2kvm#1](https://github.com/storpool/any2kvm/pull/1) and installed in the conversion host `/usr/bin/`.
+Until the upstream fix is merged, `sesparse` needs to be recompiled with the patch from [storpool/any2kvm#1](https://github.com/storpool/any2kvm/pull/1) and installed in the conversion Host's `/usr/bin/` directory.

--- a/content/software/release_information/release_notes/known_issues.md
+++ b/content/software/release_information/release_notes/known_issues.md
@@ -148,3 +148,9 @@ RAW=[
   DATA="lxc.apparmor.profile=unconfined",
   TYPE="lxc" ]
 ```
+
+## OneSwap 
+
+OneSwap delta migration may fail on vCenter/ESXi 8 and newer because the sesparse tool used to apply VMware seSparse snapshot deltas was tested against older vCenter/ESXi versions.
+
+Until the upstream fix is merged, `sesparse` needs to be recompiled with the patch from [storpool/any2kvm#1](https://github.com/storpool/any2kvm/pull/1) and installed in the conversion host `/usr/bin/`.


### PR DESCRIPTION
### Description

  Adds a known issue for OneSwap delta migration on vCenter/ESXi 8 and newer.

  Delta migration may fail because the `sesparse` tool used to apply VMware
  `seSparse` snapshot deltas was tested against older vCenter/ESXi versions.
  The known issue points users to the upstream fix:

  - https://github.com/storpool/any2kvm/pull/1

  It also notes that `sesparse` needs to be rebuilt with that patch and installed
  in `/usr/bin/` on the conversion host.

### Branches to which this PR applies

- [x] master
- [x] one-7.2
- [X] one-7.2-maintenance