### PR TITLE
F OpenNebula/one#7727: Updated template syntax guide

### DIFF
--- a/content/platform_services/oneks/getting_started/basic_configuration.md
+++ b/content/platform_services/oneks/getting_started/basic_configuration.md
@@ -35,7 +35,7 @@ Validate the OneGate configuration using the OpenNebula OneGate [documentation](
 
 ## Transparent Proxy Configuration
 
-Verify that the [transparent proxy]({{% relref "product/virtual_machines_operation/virtual_machines_networking/tproxy/" %}}) is configured to expose OneGate and the OpenNebula API through the a netowrk interconnecting the Front-end and Hosts.
+Verify that the [transparent proxy]({{% relref "product/virtual_machines_operation/virtual_machines_networking/tproxy/" %}}) is configured to expose OneGate and the OpenNebula API through the network interconnecting the Front-end and Hosts.
 
 The configuration is typically defined in the following location on the OpenNebula Front-end:
 

--- a/content/product/operation_references/configuration_references/template.md
+++ b/content/product/operation_references/configuration_references/template.md
@@ -29,15 +29,15 @@ The syntax of the template file is as follows:
 - **Strings** are delimited with double quotes `"`, if a double quote is part of the string it needs to be escaped `\\"`.
 - **Single Attributes** are in the form:
 
-```default
-NAME=VALUE
-```
+  ```default
+  NAME=VALUE
+  ```
 
 - **Vector Attributes** that contain several values can be defined as follows:
 
-```default
-NAME=[NAME1=VALUE1,NAME2=VALUE2]
-```
+  ```default
+  NAME=[NAME1=VALUE1,NAME2=VALUE2]
+  ```
 
 - **Vector Attributes** must contain at least one value.
 - The following values are permitted for **attribute names**:
@@ -53,18 +53,18 @@ Template files can be expressed in XML, with the following syntax:
 - The root element must be `TEMPLATE`.
 - **Single Attributes** are in the form:
 
-```default
-<NAME>VALUE</NAME>
-```
+  ```default
+  <NAME>VALUE</NAME>
+  ```
 
 - **Vector Attributes** that contain several values can be defined as follows:
 
-```default
-<NAME>
-  <NAME1>VALUE1</NAME1>
-  <NAME2>VALUE2</NAME2>
-</NAME>
-```
+  ```default
+  <NAME>
+    <NAME1>VALUE1</NAME1>
+    <NAME2>VALUE2</NAME2>
+  </NAME>
+  ```
 
 A simple example:
 
@@ -336,7 +336,7 @@ DISK = [ TYPE     = swap,
          SIZE     = 1024 ]
 ```
 
-Because this VM did not declare a `CONTEXT` or any disk using a `CDROM` Image, the first `DATABLOCK` found is placed right after the OS Image, in `sdb`. For more information on Image management and moving please check the [Storage guide]({{% relref "../../cluster_configuration/storage_system/overview#sm" %}}).
+Because this VM did not declare a `CONTEXT` or any disk using a `CDROM` Image, the first `DATABLOCK` found is placed right after the OS Image, in `sdb`. For more information on Image management and moving please check the [Storage guide]({{% relref "product/cluster_configuration/storage_system/overview#sm" %}}).
 
 <a id="template-network-section"></a>
 
@@ -393,7 +393,7 @@ NIC = [ NETWORK = "Test", NAME = "TestName" ]
 NIC_ALIAS = [ NETWORK = "Test", PARENT = "TestName" ]
 ```
 
-For more information on setting up virtual networks please check the [Managing Virtual Networks guide]({{% relref "../../cluster_configuration/networking_system/manage_vnets#manage-vnets" %}}).
+For more information on setting up virtual networks please check the [Managing Virtual Networks guide]({{% relref "product/cluster_configuration/networking_system/manage_vnets#manage-vnets" %}}).
 
 <a id="nic-default-template"></a>
 
@@ -573,7 +573,7 @@ GRAPHICS = [
 For the KVM hypervisor the port number is a real one, not the VNC port. So for VNC port 0 you should specify 5900, for port 1, 5901 and so on.{{< /alert >}} 
 
 {{< alert title="Warning" type="warning" >}}
-OpenNebula will prevent VNC port collision within a cluster to ensure that a VM can be deployed or migrated to any Host in the selected cluster. If the selected port is in use, the VM deployment will fail. If the user does not specify the port variable, OpenNebula will try to assign `VNC_PORTS[START] + VMID`, or the first lower available port. The `VNC_PORTS[START]` is specified inside the `oned.conf` file.{{< /alert >}} 
+OpenNebula will prevent VNC port collision within a Cluster to ensure that a VM can be deployed or migrated to any Host in the selected Cluster. If the selected port is in use, the VM deployment will fail. If the user does not specify the port variable, OpenNebula will try to assign `VNC_PORTS[START] + VMID`, or the first lower available port. The `VNC_PORTS[START]` is specified inside the `oned.conf` file.{{< /alert >}} 
 
 <a id="template-context"></a>
 
@@ -1067,7 +1067,8 @@ For example:
 
 In Sunstone, the `USER_INPUTS` can be ordered with the mouse.
 
-![user_inputs](/images/sunstone_user_inputs.png)
+
+{{< image path="/images/sunstone_user_inputs.png" alt="Sunstone user inputs" align="center" width="90%" mb="20px" >}}
 
 <a id="template-user-inputs-metadata"></a>
 
@@ -1179,7 +1180,7 @@ NUMA_NODE = [ MEMORY = 1024, TOTAL_CPUS = 2 ]
 NUMA_NODE = [ MEMORY = 2048, TOTAL_CPUS = 4 ]
 ```
 
-Please [check the NUMA guide]({{% relref "../../cluster_configuration/hosts_and_clusters/numa#numa" %}}) for more information.
+Please [check the NUMA guide]({{% relref "product/cluster_configuration/hosts_and_clusters/numa#numa" %}}) for more information.
 
 <a id="tpm-section"></a>
 
@@ -1235,8 +1236,8 @@ SUNSTONE = [
 ]
 ```
 
-![sunstone_network_options](/images/sunstone_network_options.png)
+{{< image path="/images/sunstone_network_options.png" alt="Sunstone network options" align="center" width="90%" mb="20px" >}}
 
-![sunstone_network_options-2](/images/sunstone_network_options-2.png)
+{{< image path="/images/sunstone_network_options-2.png" alt="Sunstone network options 2" align="center" width="90%" mb="20px" >}}
 
-![sunstone_network_options-3](/images/sunstone_network_options-3.png)
+{{< image path="/images/sunstone_network_options-3.png" alt="Sunstone network options 3" align="center" width="90%" mb="20px" >}}

--- a/content/product/operation_references/configuration_references/template.md
+++ b/content/product/operation_references/configuration_references/template.md
@@ -25,7 +25,7 @@ If not explicitly stated, the described attributes are valid for all supported h
 
 The syntax of the template file is as follows:
 
-- Anything behind the pound or hash sign `#` is a **comment**.
+- Anything after a hash (or pound) sign `#` on a line is a **comment**.
 - **Strings** are delimited with double quotes `"`, if a double quote is part of the string it needs to be escaped `\\"`.
 - **Single Attributes** are in the form:
 
@@ -40,7 +40,11 @@ NAME=[NAME1=VALUE1,NAME2=VALUE2]
 ```
 
 - **Vector Attributes** must contain at least one value.
-- Attribute names are case insensitive, in fact the names are converted to uppercase internally.
+- The following values are permitted for **attribute names**:
+  * Letters: `A-Z` (lower case letters are allowed, but are automatically capitalized internally)
+  * Digits: `0-9`
+  * Underscore: `_`
+
 
 ## XML Syntax
 

--- a/content/product/operation_references/configuration_references/template.md
+++ b/content/product/operation_references/configuration_references/template.md
@@ -41,7 +41,7 @@ NAME=[NAME1=VALUE1,NAME2=VALUE2]
 
 - **Vector Attributes** must contain at least one value.
 - The following values are permitted for **attribute names**:
-  * Letters: `A-Z` (lower case letters are allowed, but are automatically capitalized internally)
+  * Letters: `A-Z` (lowercase letters are allowed, but are automatically capitalized internally)
   * Digits: `0-9`
   * Underscore: `_`
 


### PR DESCRIPTION
### Description

This PR updates the template syntax guide with permitted values for the attribute names. Also fixes a minor typo in basic_configuration.md

### Branches to which this PR applies>

- [x] master
- [x] one-7.2
- [x] one-7.2-maintenance

