### PR TITLE
M #-: add step to remove key on hugo publish workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -99,3 +99,12 @@ jobs:
           HOST: ${{ secrets.HOST }}
           HOST_PATH: ${{ secrets.HOST_PATH }}
         run: ruby ./publish/publish.rb ${{ steps.get_branch.outputs.branch }}
+     
+      # ------------------------------------------------------------------------------
+      # Cleanup SSH private key
+      # ------------------------------------------------------------------------------
+      
+      - name: Cleanup SSH private key
+        if: always()
+        run: |
+          shred -u /tmp/id_rsa || rm -f /tmp/id_rsa


### PR DESCRIPTION
### Description

Improve security posture by removing the private ssh-key

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-7.0
- [ ] one-7.0-maintenance
- [ ] one-7.2-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
