### PR TITLE
Document usage of integrated ssh agent when testing passwordless ssh

### DIFF
--- a/content/software/installation_process/cluster_installation/kvm_node_installation.md
+++ b/content/software/installation_process/cluster_installation/kvm_node_installation.md
@@ -213,20 +213,29 @@ scp -p /var/lib/one/.ssh/id_rsa <node3>:/var/lib/one/.ssh/
 
 You should verify that none of these connections (under user `oneadmin`) fail and none require a password:
 
-* from the Front-end to Front-end itself
-* from the Front-end to all nodes
-* from all nodes to all nodes
-* from all nodes back to Front-end
+* From the Front-end to Front-end itself
+* From the Front-end to all nodes
+* From all nodes to all nodes
+* From all nodes back to Front-end
+
+{{< alert title="SSH Agent Forwarding" type="info" >}}
+If you are using the integrated SSH authentication agent service (and did not distribute the private key to the nodes), you must use the agent socket on the Front-end and pass the agent forwarding flag `-A` on your initial connections to nodes. This securely proxies your authentication keys through the hop to validate multi-hop connections.
+
+If you followed the optional step to manually distribute the oneadmin private key to your nodes, exporting the socket and utilizing the `-A` flag is not required.
+{{< /alert >}}
 
 For example, execute on the Front-end:
 
 ```shell
+# use the integrated SSH authentication agent
+export SSH_AUTH_SOCK=/var/run/one/ssh-agent.sock
+
 # from Front-end to Front-end itself
 ssh <frontend>
 exit
 
 # from Front-end to node, back to Front-end and to other nodes
-ssh <node1>
+ssh -A <node1>
 ssh <frontend>
 exit
 ssh <node2>
@@ -236,7 +245,7 @@ exit
 exit
 
 # from Front-end to node, back to Front-end and to other nodes
-ssh <node2>
+ssh -A <node2>
 ssh <frontend>
 exit
 ssh <node1>
@@ -246,7 +255,7 @@ exit
 exit
 
 # from Front-end to nodes and back to Front-end and other nodes
-ssh <node3>
+ssh -A <node3>
 ssh <frontend>
 exit
 ssh <node1>

--- a/content/software/installation_process/cluster_installation/lxc_node_installation.md
+++ b/content/software/installation_process/cluster_installation/lxc_node_installation.md
@@ -198,15 +198,24 @@ You should verify that none of these connections (under user `oneadmin`) fail an
 * From all nodes to all nodes
 * From all nodes back to Front-end
 
+{{< alert title="SSH Agent Forwarding" type="info" >}}
+If you are using the integrated SSH authentication agent service (and did not distribute the private key to the nodes), you must use the agent socket on the Front-end and pass the agent forwarding flag `-A` on your initial connections to nodes. This securely proxies your authentication keys through the hop to validate multi-hop connections.
+
+If you followed the optional step to manually distribute the oneadmin private key to your nodes, exporting the socket and utilizing the `-A` flag is not required.
+{{< /alert >}}
+
 For example, execute on the Front-end:
 
 ```shell
+# use the integrated SSH authentication agent
+export SSH_AUTH_SOCK=/var/run/one/ssh-agent.sock
+
 # from Front-end to Front-end itself
 ssh <frontend>
 exit
 
 # from Front-end to node, back to Front-end and to other nodes
-ssh <node1>
+ssh -A <node1>
 ssh <frontend>
 exit
 ssh <node2>
@@ -216,7 +225,7 @@ exit
 exit
 
 # from Front-end to node, back to Front-end and to other nodes
-ssh <node2>
+ssh -A <node2>
 ssh <frontend>
 exit
 ssh <node1>
@@ -226,7 +235,7 @@ exit
 exit
 
 # from Front-end to nodes and back to Front-end and other nodes
-ssh <node3>
+ssh -A <node3>
 ssh <frontend>
 exit
 ssh <node1>


### PR DESCRIPTION
### Description

Closes https://github.com/OpenNebula/one/issues/7737

Document that users must use the integrated ssh agent service socket when validating multi-hop SSH connections

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
