### PR TITLE
M #~: Fixed Accelerated Infrastructure table in platform notes

### DIFF
--- a/content/software/release_information/release_notes/platform_notes.md
+++ b/content/software/release_information/release_notes/platform_notes.md
@@ -81,7 +81,7 @@ More information: [one-apps wiki](https://github.com/OpenNebula/one-apps/wiki)
 
 ### Storage Infrastructure
 
-| **Component** | **Version**                                    | **More information**                                                                                             |
+| **Component** | **Version**  | **More information**                                                                                             |
 |-----------|--------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | iSCSI     | Version included in the Linux distribution | [LVM Drivers]({{% relref "../../../product/cluster_configuration/lvm" %}})                                   |
 | LVM2      | Version included in the Linux distribution | [LVM Drivers]({{% relref "../../../product/cluster_configuration/lvm" %}})                                   |
@@ -92,7 +92,7 @@ More information: [one-apps wiki](https://github.com/OpenNebula/one-apps/wiki)
 
 ### Accelerated Infrastructure
 
-| **Component** | **Models** | 
+| **Component** | **Models/Generations** | 
 |-----------|--------------------------------------------|
 | Ampere GPUs  | A10, A30, A40, A100 8.0 | 
 | Ada Lovelace GPUs   | L4, L40, L40S 8.9 | 

--- a/content/software/release_information/release_notes/platform_notes.md
+++ b/content/software/release_information/release_notes/platform_notes.md
@@ -98,7 +98,7 @@ More information: [one-apps wiki](https://github.com/OpenNebula/one-apps/wiki)
 | Ada Lovelace GPUs   | L4, L40, L40S 8.9 | 
 | Hopper GPUs      | H100, H200, GH200 9.0  | 
 | Blackwell GPUs   | B200, B300, GB200, GB300  | 
-| Blackwell GPUs   | 2, 3 | 
+| BlueField DPUs   | 2, 3 | 
 
 ### Authentication
 


### PR DESCRIPTION
### Description

Minor error fix: replaced Blackwell GPUs with BlueField DPUs in the final line of the Accelerated Infrastructure table of Platform Notes. 

### Branches to which this PR applies

- [x] master
- [x] one-7.2
- [x] one-7.2-maintenance
