### PR TITLE
F OpenNebula/one#7731: Added OneKS quickstart in Getting Started

### DIFF
--- a/content/getting_started/try_opennebula/opennebula_sandbox_deployment/deploy_opennebula_on_aws.md
+++ b/content/getting_started/try_opennebula/opennebula_sandbox_deployment/deploy_opennebula_on_aws.md
@@ -401,6 +401,4 @@ Congratulations! You've now installed an OpenNebula Front-end on an AWS instance
 Now that you have a working miniONE OpenNebula installation, we suggest that you explore OpenNebula's functionality further with the following guides:
 
 * [Deploy a WordPress Virtual Machine]({{% relref "/getting_started/try_opennebula/opennebula_sandbox_deployment/validate_the_environment.md#downloading-and-deploying-a-virtual-machine" %}})
-* [Deploy a Kubernetes Cluster with the OneKE appliance]({{% relref "/getting_started/try_opennebula/try_kubernetes_on_opennebula/running_kubernetes_clusters.md" %}})
-* [Deploy a Kubernetes Cluster using Rancher and the Cluster API]({{% relref "/getting_started/try_opennebula/try_kubernetes_on_opennebula/managing_k8s_with_rancher" %}})
 * [Further validate your miniONE installation]({{% relref "/getting_started/try_opennebula/opennebula_sandbox_deployment/validate_the_environment.md" %}}) and learn how to download appliances from the [OpenNebula Marketplace](https://marketplace.opennebula.io/)

--- a/content/getting_started/try_opennebula/opennebula_sandbox_deployment/deploy_opennebula_onprem_with_minione.md
+++ b/content/getting_started/try_opennebula/opennebula_sandbox_deployment/deploy_opennebula_onprem_with_minione.md
@@ -257,8 +257,6 @@ Congratulations! You've now installed an OpenNebula Front-end with a KVM hypervi
 Now that you have a working miniONE OpenNebula installation, we suggest that you explore OpenNebula's functionality further with the following guides:
 
 * [Deploy a WordPress Virtual Machine]({{% relref "/getting_started/try_opennebula/opennebula_sandbox_deployment/validate_the_environment.md#downloading-and-deploying-a-virtual-machine" %}})
-* [Deploy a Kubernetes Cluster with the OneKE Appliance]({{% relref "/getting_started/try_opennebula/try_kubernetes_on_opennebula/running_kubernetes_clusters.md" %}})
-* [Deploy a Kubernetes Cluster using Rancher and the Cluster API]({{% relref "/getting_started/try_opennebula/try_kubernetes_on_opennebula/managing_k8s_with_rancher" %}})
 * [Further validate your miniONE Installation]({{% relref "/getting_started/try_opennebula/opennebula_sandbox_deployment/validate_the_environment.md" %}}) and learn how to download appliances from the [OpenNebula Marketplace](https://marketplace.opennebula.io/)
 
 ## SSH and Port Forwarding

--- a/content/getting_started/try_opennebula/opennebula_sandbox_deployment/deploy_opennebula_onprem_with_poc_iso.md
+++ b/content/getting_started/try_opennebula/opennebula_sandbox_deployment/deploy_opennebula_onprem_with_poc_iso.md
@@ -624,5 +624,3 @@ Search for vLLM appliance and import it. Select DataStore where to save image
 ## Next Steps
 
 Additionally, we recommend checking [Validate the environment]({{% relref "validate_the_environment" %}}), that describes how to explore the resources installed and how to download and run appliances from the [OpenNebula Marketplace](https://marketplace.opennebula.io/).
-
-Finally, you can use your OpenNebula installation to [Run a Kubernetes Cluster on OpenNebula]({{% relref "running_kubernetes_clusters" %}}) with minimal steps -- first downloading the OneKE Service from the OpenNebula Public Marketplace, then  deploying a full-fledged K8s cluster with a test application.

--- a/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/managing_k8s_with_rancher.md
+++ b/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/managing_k8s_with_rancher.md
@@ -3,6 +3,7 @@ title: "Managing Kubernetes with Rancher and the Cluster API"
 date: "2025-02-17"
 type: docs
 description:
+toc_hide: true
 ---
 
 <a id="running-kubernetes-clusters"></a>

--- a/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/oneks_quickstart.md
+++ b/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/oneks_quickstart.md
@@ -5,7 +5,7 @@ date: "2025-02-17"
 description:
 categories: [Learning, Evaluation, Deployment, Introduction]
 pageintoc: "23"
-tags: ['Quick Start', Kubernetes, Tutorial, OneKE]
+tags: ['Quick Start', Kubernetes, Tutorial]
 type: docs
 weight: "7"
 ---

--- a/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/oneks_quickstart.md
+++ b/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/oneks_quickstart.md
@@ -1,0 +1,72 @@
+---
+title: "Quickstart: Elastic Kubernetes on OpenNebula with OneKS (EE)"
+linkTitle: "OneKS Quickstart Guide (EE)"
+date: "2025-02-17"
+description:
+categories: [Learning, Evaluation, Deployment, Introduction]
+pageintoc: "23"
+tags: ['Quick Start', Kubernetes, Tutorial, OneKE]
+type: docs
+weight: "7"
+---
+
+## Overview
+
+OneKS provides Elastic Kubernetes-as-a-Service on OpenNebula. It offers a streamlined, structured way to create, access, operate, upgrade, recover, and deprovision Kubernetes Clusters (K8s Clusters) by combining a user-facing service layer with Cluster API-based infrastructure provisioning through CAPONE, the Cluster API provider for OpenNebula. This quickstart guide leads you through the steps to try OneKS with a simple example deployment.
+
+OneKS is an Enterprise Extension available as part of an Enterprise Subscription. Please see the [documentation about Enterprise Subscriptions and Extensions]({{% relref "software/release_information/release_notes/editions/" %}}) for more information or visit the [OpenNebula website](https://opennebula.io/enterprise-services/#subscriptions) for information about acquiring an Enterprise Subscription. 
+
+## Installation
+
+OneKS requires a full OpenNebula Front-end installation with at least one Cluster node installed using the Enterprise Edition package repositories (OneKS is not supported by miniONE). Proceed with the following steps (in the given order) to install OpenNebula Enterprise Edition and OneKS.
+
+### 1. Install an OpenNebula Front-end
+
+The Front-end serves as the control plane of an OpenNebula cloud deployment. It manages all aspects of an OpenNebula-managed cloud including K8s Clusters deployed with OneKS. Follow these steps (in the given order) to deploy and OpenNebula Front-end:
+
+* Ensure that your hardware meets the [requirements]({{% relref "software/installation_process/frontend_installation/overview/#requirements" %}})
+* [Install a database]({{% relref "software/installation_process/frontend_installation/database/" %}}) to persist the cloud state
+* [Set up the Enterprise Edition repositories]({{% relref "software/installation_process/frontend_installation/opennebula_repository_configuration_ee/" %}})
+* [Install an OpenNebula Front-end]({{% relref "software/installation_process/frontend_installation/frontend_install/" %}})
+
+### 2. Install an OpenNebula Cluster
+
+An OpenNebula Cluster is a logical grouping of Hosts, datastores and Virtual Networks that provide compute capacity for cloud workloads. After deploying an OpenNebula Front-end, you must deploy at least one OpenNebula Cluster to handle the guest workload of a K8s Cluster. There are 2 options to deploy an OpenNebula Cluster to host a K8s Cluster:
+
+* [Automated Cluster deployment with OneForm]({{% relref "software/installation_process/cluster_installation/automated/" %}})
+* [Manual Cluster installation with KVM]({{% relref "software/installation_process/cluster_installation/kvm_node_installation/" %}})
+
+## Configuration
+
+Before deploying a K8s Cluster, it is necessary to ensure that the OpenNebula cloud is properly configured for OneKS. Refer to the [OneKS Basic Configuration Guide]({{% relref "platform_services/oneks/getting_started/basic_configuration/" %}}) to prepare your OpenNebula cloud for OneKS.
+
+## Deploy a K8s Cluster with OneKS
+
+Once you have deployed a Front-end and at least one OpenNebula Cluster and completed configuration, you are ready to try deploying a K8s Cluster with OneKS. Follow the steps in the [OneKS Quick-start Guide]({{% relref "platform_services/oneks/getting_started/quick_start/" %}}) to deploy your first K8s Cluster. 
+
+## Next Steps
+
+After learning how to deploy a K8s Cluster with OneKS, the next step is learning to manage, monitor, and troubleshoot Cluster lifecycles, refer to the following guides for more information:
+
+* [K8s Cluster Lifecycle Management]({{% relref "platform_services/oneks/management/k8s_cluster_lifecycle_management/" %}})
+* [Monitoring and Troubleshooting]({{% relref "platform_services/oneks/management/monitoring_and_troubleshooting/" %}})
+* [Configuration]({{% relref "platform_services/oneks/management/configuration/" %}})
+* [Profiles Customization]({{% relref "platform_services/oneks/management/customizing_specs/" %}})
+
+OneKS is can be managed through 3 interfaces: the Sunstone web UI, CLI and REST API. Refer to the following references for more details: 
+
+* [OneKS REST API]({{% relref "platform_services/oneks/references/oneks_api/" %}})
+* [OneKS CLI]({{% relref "platform_services/oneks/references/oneks_cli/" %}})
+* [Service Architecture]({{% relref "platform_services/oneks/references/architecture/" %}})
+
+
+
+
+
+
+
+
+
+
+
+

--- a/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/running_kubernetes_clusters.md
+++ b/content/getting_started/try_opennebula/try_kubernetes_on_opennebula/running_kubernetes_clusters.md
@@ -7,6 +7,7 @@ pageintoc: "23"
 tags: ['Quick Start', Kubernetes, Tutorial, OneKE]
 type: docs
 weight: "7"
+toc_hide: true
 ---
 
 <a id="running-kubernetes-clusters"></a>

--- a/content/getting_started/understand_opennebula/opennebula_concepts/key_features.md
+++ b/content/getting_started/understand_opennebula/opennebula_concepts/key_features.md
@@ -160,7 +160,7 @@ Comprehensive isolation, quota management, and access controls ensure secure mul
 
 Enterprise-grade Kubernetes management and orchestration through built-in add-ons.
 
-* OpenNebula Kubernetes Service (OneKS): Provides elastic Kubernetes-as-a-Service on OpenNebula, enabling users to create, access, operate, upgrade, recover, and deprovision Kubernetes clusters in a simple and repeatable way.
+* OpenNebula Kubernetes Service (OneKS): Provides elastic Kubernetes-as-a-Service on OpenNebula, enabling users to create, access, operate, upgrade, recover, and deprovision Kubernetes Clusters in a simple and repeatable way.
 * Cluster API / CAPONE: Native support for Cluster API Provider for OpenNebula to automate Kubernetes infrastructure provisioning and lifecycle management.
 * Cloud Provider Interface (CPI): Direct integration between Kubernetes and OpenNebula-managed compute, networking, and infrastructure resources.
 * Container Storage Interface (CSI): Persistent volume provisioning from OpenNebula storage backends.

--- a/content/getting_started/understand_opennebula/opennebula_concepts/opennebula_overview.md
+++ b/content/getting_started/understand_opennebula/opennebula_concepts/opennebula_overview.md
@@ -31,11 +31,9 @@ An OpenNebula infrastructure can be deployed on-premises, in the cloud, at the e
 
 OpenNebula can manage both single VMs and complex multi-tier services composed of several VMs that require sophisticated elasticity rules and dynamic adaptability. Elements in the OpenNebula infrastructure—such as Virtual Machines, networks, and appliances—are created from images and templates. Users can modify existing templates or create new ones. Cloud administrators can share templates across their organizations, either directly or using a private corporate Marketplace. Additionally, the [OpenNebula Public Marketplace](https://marketplace.opennebula.io) offers pre-defined, fully-functional templates for download and deployment, including for multi-VM applications and virtual devices.
 
-### Containerized Applications through Kubernetes
+### Containerized Applications with Elastic Kubernetes
 
-OpenNebula supports the automated deployment of Kubernetes Clusters through a virtual appliance, **OneKE**, the OpenNebula Kubernetes Engine. OneKE is an enterprise-grade, CNCF-certified Kubernetes distribution based on SUSE Rancher RKE2. In its basic configuration it comprises four Virtual Machines: the Kubernetes master node, a VNF node, a storage node, and a worker node. It can be configured as a multi-master Cluster for high availability, and easily scaled up to include more worker nodes, either before deployment or dynamically during operation, by using elasticity rules. It includes features such as MetalLB load balancing, Multus and Cilium CNI plugins, and Longhorn storage. It is available as a multi-VM appliance on the OpenNebula Marketplace and can be installed in minutes using Sunstone, OpenNebula’s web UI.
-
-{{< image path="/images/overview_containers.svg" alt="OneKE Architecture with Containerized Applications" align="center" width="80%" mb="20px" border="false" >}}
+OpenNebula supports the automated deployment of Kubernetes Clusters through OneKS, the OpenNebula Elastic Kubernetes Service. OneKS provides Kubernetes-as-a-Service on top of OpenNebula, offering a structured way to create, access, operate, scale, upgrade, recover, and deprovision Kubernetes Clusters across cloud and edge environments. It combines a user-facing service layer with Cluster API-based infrastructure provisioning through CAPONE, the Cluster API provider for OpenNebula. With OneKS, users work with high-level Kubernetes resources such as K8s Clusters and node groups, while OpenNebula, the Cluster API, CAPONE, and supporting infrastructure resources are orchestrated underneath.
 
 ### Management Model and Tools
 

--- a/content/getting_started/understand_opennebula/opennebula_concepts/opennebula_overview.md
+++ b/content/getting_started/understand_opennebula/opennebula_concepts/opennebula_overview.md
@@ -33,7 +33,7 @@ OpenNebula can manage both single VMs and complex multi-tier services composed o
 
 ### Containerized Applications with Elastic Kubernetes
 
-OpenNebula supports the automated deployment of Kubernetes Clusters through OneKS, the OpenNebula Elastic Kubernetes Service. OneKS provides Kubernetes-as-a-Service on top of OpenNebula, offering a structured way to create, access, operate, scale, upgrade, recover, and deprovision Kubernetes Clusters across cloud and edge environments. It combines a user-facing service layer with Cluster API-based infrastructure provisioning through CAPONE, the Cluster API provider for OpenNebula. With OneKS, users work with high-level Kubernetes resources such as K8s Clusters and node groups, while OpenNebula, the Cluster API, CAPONE, and supporting infrastructure resources are orchestrated underneath.
+OpenNebula supports the automated deployment of Kubernetes Clusters through OneKS, the OpenNebula Elastic Kubernetes Service. OneKS provides Kubernetes-as-a-Service on top of OpenNebula, offering a structured way to create, access, operate, scale, upgrade, recover, and deprovision Kubernetes Clusters across cloud and edge environments. It combines a user-facing service layer with Cluster API-based infrastructure provisioning through CAPONE, the Cluster API provider for OpenNebula.
 
 ### Management Model and Tools
 

--- a/content/platform_services/oneks/_index.md
+++ b/content/platform_services/oneks/_index.md
@@ -1,8 +1,8 @@
 ---
-title: "Elastic Kubernetes as a Service (EE)"
+title: "Elastic Kubernetes-as-a-Service (EE)"
 linkTitle: "Elastic Kubernetes (EE)"
 date: "2026-05-12"
-description: "OneKS provides Elastic Kubernetes as a Service on OpenNebula. It offers a structured way to create, access, operate, upgrade, recover, and deprovision Kubernetes Clusters."
+description: "OneKS provides Elastic Kubernetes-as-a-Service on OpenNebula. It offers a structured way to create, access, operate, upgrade, recover, and deprovision Kubernetes Clusters."
 categories:
 pageintoc: "13"
 tags:

--- a/content/platform_services/oneks/getting_started/overview.md
+++ b/content/platform_services/oneks/getting_started/overview.md
@@ -20,6 +20,7 @@ OneKS builds on CAPONE to expose a K8s Cluster-centric lifecycle model for users
 If you have not used OneKS before, you should start by reading the [Basic Configuration Guide]({{% relref "platform_services/oneks/getting_started/basic_configuration/" %}}) to set up OneKS then follow the [Quick-start Guide]({{% relref "platform_services/oneks/getting_started/quick_start/" %}}) where you will learn to set up a basic K8s Cluster with OneKS. After completing the Quick-start Guide, move on to [Core Concepts]({{% relref "platform_services/oneks/getting_started/core_concepts/" %}}) to familiarize yourself with key OneKS concepts. 
 
 After completing the introductory documentation, you can find more information about managing K8s Clusters with OneKS in the following reference documentation:
+
 * [K8s Cluster Lifecycle Management]({{% relref "platform_services/oneks/management/k8s_cluster_lifecycle_management/" %}})
 * [Monitoring and Troubleshooting]({{% relref "platform_services/oneks/management/monitoring_and_troubleshooting/" %}})
 * [Configuration]({{% relref "platform_services/oneks/management/configuration/" %}})

--- a/content/platform_services/oneks/getting_started/overview.md
+++ b/content/platform_services/oneks/getting_started/overview.md
@@ -9,7 +9,7 @@ weight: "1"
 type: docs
 ---
 
-OneKS provides Elastic Kubernetes as a Service on OpenNebula. It offers a structured way to create, access, operate, upgrade, recover, and deprovision Kubernetes Clusters (K8s Clusters) by combining a user-facing service layer with Cluster API-based infrastructure provisioning through CAPONE, the Cluster API provider for OpenNebula.
+OneKS provides Elastic Kubernetes-as-a-Service on OpenNebula. It offers a structured way to create, access, operate, upgrade, recover, and deprovision Kubernetes Clusters (K8s Clusters) by combining a user-facing service layer with Cluster API-based infrastructure provisioning through CAPONE, the Cluster API provider for OpenNebula.
 
 OneKS is designed for teams that need a simple and repeatable way to consume Kubernetes inside OpenNebula. Typical use cases include development and test environments, self-service Kubernetes delivery in private cloud environments, and standardized Cluster offerings for different sizes and topologies.
 

--- a/content/platform_services/oneks/getting_started/quick_start.md
+++ b/content/platform_services/oneks/getting_started/quick_start.md
@@ -1,6 +1,7 @@
 ---
-title: "Quick Start"
-linkTitle: "Quick Start"
+title: "OneKS Quickstart"
+linkTitle: "Quickstart"
+cardTitle: "Quickstart"
 date: "2026-05-12"
 description:
 categories:

--- a/content/platform_services/oneks/references/architecture.md
+++ b/content/platform_services/oneks/references/architecture.md
@@ -1,6 +1,7 @@
 ---
-title: "Service Architecture"
+title: "OneKS Service Architecture"
 linkTitle: "Service Architecture"
+cardTitle: "Service Architecture"
 date: "2026-05-12"
 description:
 categories:

--- a/content/platform_services/oneks/references/oneks_api.md
+++ b/content/platform_services/oneks/references/oneks_api.md
@@ -1,6 +1,7 @@
 ---
-title: "REST API Reference"
+title: "OneKS REST API Reference"
 linkTitle: "API"
+cardTitle: "REST API Reference"
 date: "2026-05-12"
 description:
 categories:

--- a/content/platform_services/oneks/references/oneks_cli.md
+++ b/content/platform_services/oneks/references/oneks_cli.md
@@ -1,6 +1,7 @@
 ---
-title: "CLI Reference"
+title: "OneKS CLI Reference"
 linkTitle: "CLI"
+cardTitle: "CLI Reference"
 date: "2026-05-12"
 description:
 categories:

--- a/content/product/apps-marketplace/managing_marketplaces/marketapps.md
+++ b/content/product/apps-marketplace/managing_marketplaces/marketapps.md
@@ -40,13 +40,6 @@ $ onemarketapp list
     22 Alpine Linux 3.18                     6.10.0-2-2  256M  rdy  img 05/14/24 OpenNebula    0
     21 Oracle Linux 9                        6.10.0-2-2   37G  rdy  img 05/14/24 OpenNebula    0
     20 ALT Linux p9                          6.8.1-1-20  1.5G  rdy  img 02/01/24 OpenNebula    0
-    19 OneKE 1.29 Airgapped Storage          1.29.4-6.1    0M  rdy  tpl 05/10/24 OpenNebula    0
-    18 OneKE 1.29 Airgapped OS disk          1.29.4-6.1   25G  rdy  img 05/10/24 OpenNebula    0
-    17 OneKE 1.29 Airgapped                  1.29.4-6.1    0M  rdy  tpl 05/10/24 OpenNebula    0
-    16 Service OneKE 1.29 Airgapped          1.29.4-6.1    0M  rdy  srv 05/10/24 OpenNebula    0
-    15 OneKE 1.29                            1.29.2-6.1    0M  rdy  tpl 05/10/24 OpenNebula    0
-    14 OneKE 1.29 OS disk                    1.29.2-6.1   25G  rdy  img 05/10/24 OpenNebula    0
-    13 OneKE 1.29 VNF                        1.29.2-6.1    2G  rdy  img 05/15/24 OpenNebula    0
 ```
 
 To get more details of an Appliance use the `show` option, for example:

--- a/content/software/release_information/release_notes/.resolved_issues_template.md
+++ b/content/software/release_information/release_notes/.resolved_issues_template.md
@@ -7,7 +7,7 @@ date: "20XX-YY-ZZ"
 
 A complete list of solved issues for X.Y.Z are listed in the [project development portal](https://github.com/OpenNebula/one/milestone/XYZ).
 
-## Elastic Kubernetes as a Service
+## Elastic Kubernetes-as-a-Service
 [OneKS]({{% relref "platform_services/oneks/getting_started/overview/" %}}) is a new OpenNebula service that streamlines and simplifies the provisioning and operation of Kubernetes Clusters on OpenNebula cloud deployments. OneKS builds on CAPONE to expose a Cluster-centric lifecycle model for users needing a simple and repeatable way to consume Kubernetes inside OpenNebula.
 
 ## Backported Issues

--- a/content/software/release_information/release_notes/editions.md
+++ b/content/software/release_information/release_notes/editions.md
@@ -11,6 +11,8 @@ weight: "7"
 
 OpenNebula offers a range of subscriptions and extensions to suit various operational and business requirements. Organizations can choose subscription models that provide support, maintenance, and access to additional software extensions. 
 
+The OpenNebula documentation uses the following suffixes in page titles to identify which features are extensions related to a specific subscription or software edition:
+
 * **EE** - Refers to features that are Enterprise Extensions and are only available to customers with an Enterprise Subscription
 * **AE** - Refers to features that are AI Factory Extensions and are only available to customers with an AI Factory Subscription
 * **CE** - Refers to the Community Edition, available to all users


### PR DESCRIPTION
### Description

This PR replaces the Try Kubernetes on OpenNebula guides for the OneKE and CAPI appliances with a OneKS quickstart guide referencing the existing OneKS documentation in Platform Services. 

### Branches to which this PR applies

- [x] master
- [x] one-7.2
- [x] one-7.2-maintenance 